### PR TITLE
Refactor to use shared context schema matcher

### DIFF
--- a/spec/factories/judicial_result_prompt_duration_elements.rb
+++ b/spec/factories/judicial_result_prompt_duration_elements.rb
@@ -9,7 +9,5 @@ FactoryBot.define do
     secondaryDurationValue { 1 }
     tertiaryDurationUnit { 'MyString' }
     tertiaryDurationValue { 'MyString' }
-    durationStartDate { '2019-10-15 13:15:32' }
-    durationEndDate { '2019-10-15 13:15:32' }
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,13 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Address, type: :model do
+
+  let(:address) { FactoryBot.create(:address) }
+
+  let(:json_schema) { :address }
+
+  subject { address }
+
   describe 'validations' do
     it { should validate_presence_of(:address1) }
   end
 
-  let(:address) { FactoryBot.create(:address) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(address.to_builder.target!).to match_json_schema(:address)
-  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Address, type: :model do
-
   let(:address) { FactoryBot.create(:address) }
 
   let(:json_schema) { :address }
@@ -15,5 +14,4 @@ RSpec.describe Address, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/allocation_decision_spec.rb
+++ b/spec/models/allocation_decision_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe AllocationDecision, type: :model do
 
   let(:allocation_decision) { FactoryBot.create(:allocation_decision) }
 
-  it 'matches the given schema' do
-    expect(allocation_decision.to_builder.target!).to match_json_schema(:allocation_decision)
-  end
+  let(:json_schema) { :allocation_decision }
+
+  subject { allocation_decision }
+
+  it_has_behaviour 'conforming to valid schema'
+
 end

--- a/spec/models/allocation_decision_spec.rb
+++ b/spec/models/allocation_decision_spec.rb
@@ -21,5 +21,4 @@ RSpec.describe AllocationDecision, type: :model do
   subject { allocation_decision }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/associated_person_spec.rb
+++ b/spec/models/associated_person_spec.rb
@@ -18,5 +18,4 @@ RSpec.describe AssociatedPerson, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/associated_person_spec.rb
+++ b/spec/models/associated_person_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe AssociatedPerson, type: :model do
+  let(:associated_person) { FactoryBot.create(:associated_person) }
+
+  let(:json_schema) { :associated_person }
+
+  subject { associated_person }
+
   describe 'associations' do
     it { should belong_to(:person).class_name('Person') }
   end
@@ -11,9 +17,6 @@ RSpec.describe AssociatedPerson, type: :model do
     it { should validate_presence_of(:person) }
   end
 
-  let(:associated_person) { FactoryBot.create(:associated_person) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(associated_person.to_builder.target!).to match_json_schema(:associated_person)
-  end
 end

--- a/spec/models/bail_status_spec.rb
+++ b/spec/models/bail_status_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe BailStatus, type: :model do
+
+  let(:bail_status) { FactoryBot.create(:bail_status) }
+
+  let(:json_schema) { :bail_status }
+
+  subject { bail_status }
+
   describe 'associations' do
     it { should belong_to(:custody_time_limit).class_name('CustodyTimeLimit').optional }
   end
@@ -12,20 +19,16 @@ RSpec.describe BailStatus, type: :model do
   end
 
   context 'hmcts schema' do
-    let(:bail_status) { FactoryBot.create(:bail_status) }
 
-    it 'matches the given schema' do
-      expect(bail_status.to_builder.target!).to match_json_schema(:bail_status)
-    end
+    it_has_behaviour 'conforming to valid schema'
 
     context 'with relationships' do
       before do
-        bail_status.update! custody_time_limit: FactoryBot.create(:custody_time_limit)
+        subject.update! custody_time_limit: FactoryBot.create(:custody_time_limit)
       end
 
-      it 'matches the given schema' do
-        expect(bail_status.to_builder.target!).to match_json_schema(:bail_status)
-      end
+      it_has_behaviour 'conforming to valid schema'
+
     end
   end
 end

--- a/spec/models/bail_status_spec.rb
+++ b/spec/models/bail_status_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe BailStatus, type: :model do
-
   let(:bail_status) { FactoryBot.create(:bail_status) }
 
   let(:json_schema) { :bail_status }
@@ -19,7 +18,6 @@ RSpec.describe BailStatus, type: :model do
   end
 
   context 'hmcts schema' do
-
     it_has_behaviour 'conforming to valid schema'
 
     context 'with relationships' do
@@ -28,7 +26,6 @@ RSpec.describe BailStatus, type: :model do
       end
 
       it_has_behaviour 'conforming to valid schema'
-
     end
   end
 end

--- a/spec/models/contact_number_spec.rb
+++ b/spec/models/contact_number_spec.rb
@@ -10,5 +10,4 @@ RSpec.describe ContactNumber, type: :model do
   subject { contact_number }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/contact_number_spec.rb
+++ b/spec/models/contact_number_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 RSpec.describe ContactNumber, type: :model do
   let(:contact_number) { FactoryBot.create(:contact_number) }
 
-  it 'matches the given schema' do
-    expect(contact_number.to_builder.target!).to match_json_schema(:contact_number)
-  end
+  let(:json_schema) { :contact_number }
+
+  subject { contact_number }
+
+  it_has_behaviour 'conforming to valid schema'
+
 end

--- a/spec/models/court_application_type_spec.rb
+++ b/spec/models/court_application_type_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe CourtApplicationType, type: :model do
+  let(:court_application_type) { FactoryBot.create(:court_application_type) }
+  let(:json_schema) { :court_application_type }
+
+  subject { court_application_type }
+
   describe 'validations' do
     it { should validate_presence_of(:applicationCategory) }
     it { should validate_presence_of(:applicationJurisdictionType) }
@@ -30,9 +35,6 @@ RSpec.describe CourtApplicationType, type: :model do
     end
   end
 
-  let(:court_application_type) { FactoryBot.create(:court_application_type) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(court_application_type.to_builder.target!).to match_json_schema(:court_application_type)
-  end
 end

--- a/spec/models/court_application_type_spec.rb
+++ b/spec/models/court_application_type_spec.rb
@@ -36,5 +36,4 @@ RSpec.describe CourtApplicationType, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/court_centre_spec.rb
+++ b/spec/models/court_centre_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe CourtCentre, type: :model do
+  let(:court_centre) { FactoryBot.create(:court_centre) }
+
+  let(:json_schema) { :court_centre }
+
+  subject { court_centre }
+
   describe 'associations' do
     it { should belong_to(:address).class_name('Address').optional }
   end
 
-  let(:court_centre) { FactoryBot.create(:court_centre) }
-
-  it 'matches the given schema' do
-    expect(court_centre.to_builder.target!).to match_json_schema(:court_centre)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/court_indicated_sentence_spec.rb
+++ b/spec/models/court_indicated_sentence_spec.rb
@@ -3,12 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe CourtIndicatedSentence, type: :model do
+  let(:court_indicated_sentence) { FactoryBot.create(:court_indicated_sentence) }
+
+  let(:json_schema) { :court_indicated_sentence }
+
+  subject { court_indicated_sentence }
+
   it { should validate_presence_of(:courtIndicatedSentenceTypeId) }
   it { should validate_presence_of(:courtIndicatedSentenceDescription) }
 
-  let(:court_indicated_sentence) { FactoryBot.create(:court_indicated_sentence) }
-
-  it 'matches the given schema' do
-    expect(court_indicated_sentence.to_builder.target!).to match_json_schema(:court_indicated_sentence)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/custody_time_limit_spec.rb
+++ b/spec/models/custody_time_limit_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe CustodyTimeLimit, type: :model do
+  let(:custody_time_limit) { FactoryBot.create(:custody_time_limit) }
+
+  let(:json_schema) { :custody_time_limit }
+
+  subject { custody_time_limit }
+
   describe 'validations' do
     it { should validate_presence_of(:timeLimit) }
     it { should validate_presence_of(:daysSpent) }
   end
 
-  let(:custody_time_limit) { FactoryBot.create(:custody_time_limit) }
-
-  it 'matches the given schema' do
-    expect(custody_time_limit.to_builder.target!).to match_json_schema(:custody_time_limit)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/defendant_alias_spec.rb
+++ b/spec/models/defendant_alias_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe DefendantAlias, type: :model do
+  let(:defendant_alias) { FactoryBot.create(:defendant_alias) }
+
+  let(:json_schema) { :defendant_alias }
+
+  subject { defendant_alias }
+
   describe 'validations' do
     it do
       should validate_inclusion_of(:title)
@@ -10,9 +16,5 @@ RSpec.describe DefendantAlias, type: :model do
     end
   end
 
-  let(:defendant_alias) { FactoryBot.create(:defendant_alias) }
-
-  it 'matches the given schema' do
-    expect(defendant_alias.to_builder.target!).to match_json_schema(:defendant_alias)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/delegated_powers_spec.rb
+++ b/spec/models/delegated_powers_spec.rb
@@ -3,13 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe DelegatedPowers, type: :model do
+  let(:delegated_powers) { FactoryBot.create(:delegated_powers) }
+
+  let(:json_schema) { :delegated_powers }
+
+  subject { delegated_powers }
+
   it { should validate_presence_of(:userId) }
   it { should validate_presence_of(:firstName) }
   it { should validate_presence_of(:lastName) }
 
-  let(:delegated_powers) { FactoryBot.create(:delegated_powers) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(delegated_powers.to_builder.target!).to match_json_schema(:delegated_powers)
-  end
 end

--- a/spec/models/delegated_powers_spec.rb
+++ b/spec/models/delegated_powers_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe DelegatedPowers, type: :model do
   it { should validate_presence_of(:lastName) }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/ethnicity_spec.rb
+++ b/spec/models/ethnicity_spec.rb
@@ -18,5 +18,4 @@ RSpec.describe Ethnicity, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/ethnicity_spec.rb
+++ b/spec/models/ethnicity_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe Ethnicity, type: :model do
   let(:ethnicity) { FactoryBot.create(:ethnicity) }
 
+  let(:json_schema) { :ethnicity }
+
+  subject { ethnicity }
+
   it 'matches the given schema' do
     expect(ethnicity.to_builder.target!).to match_json_schema(:ethnicity)
   end
@@ -12,4 +16,7 @@ RSpec.describe Ethnicity, type: :model do
   describe 'associations' do
     it { should have_one(:person).class_name('Person') }
   end
+
+  it_has_behaviour 'conforming to valid schema'
+
 end

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe HearingDay, type: :model do
+  let(:hearing_day) { FactoryBot.create(:hearing_day) }
+
+  let(:json_schema) { :hearing_day }
+
+  subject { hearing_day }
+
   describe 'validations' do
     it { should validate_presence_of(:sittingDay) }
     it { should validate_presence_of(:listedDurationMinutes) }
   end
 
-  let(:hearing_day) { FactoryBot.create(:hearing_day) }
-
-  it 'matches the given schema' do
-    expect(hearing_day.to_builder.target!).to match_json_schema(:hearing_day)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/hearing_type_spec.rb
+++ b/spec/models/hearing_type_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe HearingType, type: :model do
+  let(:hearing_type) { FactoryBot.create(:hearing_type) }
+
+  let(:json_schema) { :hearing_type }
+
+  subject { hearing_type }
+
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:code) }
 
-  let(:hearing_type) { FactoryBot.create(:hearing_type) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(hearing_type.to_builder.target!).to match_json_schema(:hearing_type)
-  end
 end

--- a/spec/models/hearing_type_spec.rb
+++ b/spec/models/hearing_type_spec.rb
@@ -13,5 +13,4 @@ RSpec.describe HearingType, type: :model do
   it { should validate_presence_of(:code) }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/indicated_plea_spec.rb
+++ b/spec/models/indicated_plea_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe IndicatedPlea, type: :model do
+  let(:indicated_plea) { FactoryBot.create(:indicated_plea) }
+
+  let(:json_schema) { :indicated_plea }
+
+  subject { indicated_plea }
+
   describe 'validations' do
     it { should validate_presence_of(:offenceId) }
     it { should validate_presence_of(:indicatedPleaDate) }
@@ -17,11 +23,6 @@ RSpec.describe IndicatedPlea, type: :model do
         .in_array(%w[ONLINE IN_COURT])
     end
   end
-  let(:indicated_plea) { FactoryBot.create(:indicated_plea) }
-
-  let(:json_schema) { :indicated_plea }
-
-  subject { indicated_plea }
 
   it_has_behaviour 'conforming to valid schema'
 

--- a/spec/models/indicated_plea_spec.rb
+++ b/spec/models/indicated_plea_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe IndicatedPlea, type: :model do
         .in_array(%w[ONLINE IN_COURT])
     end
   end
-
   let(:indicated_plea) { FactoryBot.create(:indicated_plea) }
 
-  it 'matches the given schema' do
-    expect(indicated_plea.to_builder.target!).to match_json_schema(:indicated_plea)
-  end
+  let(:json_schema) { :indicated_plea }
+
+  subject { indicated_plea }
+
+  it_has_behaviour 'conforming to valid schema'
+
 end

--- a/spec/models/indicated_plea_spec.rb
+++ b/spec/models/indicated_plea_spec.rb
@@ -25,5 +25,4 @@ RSpec.describe IndicatedPlea, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/judicial_result_prompt_duration_element_spec.rb
+++ b/spec/models/judicial_result_prompt_duration_element_spec.rb
@@ -26,5 +26,4 @@ RSpec.describe JudicialResultPromptDurationElement, type: :model do
     it { should validate_presence_of(:durationEndDate) }
     it_has_behaviour 'conforming to valid schema'
   end
-
 end

--- a/spec/models/judicial_result_prompt_duration_element_spec.rb
+++ b/spec/models/judicial_result_prompt_duration_element_spec.rb
@@ -4,22 +4,27 @@ require 'rails_helper'
 
 RSpec.describe JudicialResultPromptDurationElement, type: :model do
   let(:judicial_result_prompt_duration_element) { FactoryBot.create(:judicial_result_prompt_duration_element) }
+
+  let(:json_schema) { :judicial_result_prompt_duration_element }
+
+  subject { judicial_result_prompt_duration_element }
+
   context 'When primaryDurationUnit or primaryDurationValue are present' do
     it { should validate_presence_of(:primaryDurationUnit) }
     it { should validate_presence_of(:primaryDurationValue) }
+    it_has_behaviour 'conforming to valid schema'
   end
 
   context 'When durationStartDate or durationEndDate are present' do
-    subject { judicial_result_prompt_duration_element }
     before do
       judicial_result_prompt_duration_element.primaryDurationUnit = nil
       judicial_result_prompt_duration_element.primaryDurationValue = nil
+      judicial_result_prompt_duration_element.durationStartDate = '2019-10-15 13:15:32'
+      judicial_result_prompt_duration_element.durationEndDate = '2019-10-15 13:15:32'
     end
     it { should validate_presence_of(:durationStartDate) }
     it { should validate_presence_of(:durationEndDate) }
+    it_has_behaviour 'conforming to valid schema'
   end
 
-  it 'matches the given schema' do
-    expect(judicial_result_prompt_duration_element.to_builder.target!).to match_json_schema(:judicial_result_prompt_duration_element)
-  end
 end

--- a/spec/models/judicial_result_prompt_spec.rb
+++ b/spec/models/judicial_result_prompt_spec.rb
@@ -19,5 +19,4 @@ RSpec.describe JudicialResultPrompt, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/judicial_result_prompt_spec.rb
+++ b/spec/models/judicial_result_prompt_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe JudicialResultPrompt, type: :model do
+  let(:judicial_result_prompt) { FactoryBot.create(:judicial_result_prompt) }
+
+  let(:json_schema) { :judicial_result_prompt }
+
+  subject { judicial_result_prompt }
+
   describe 'associations' do
     it { should have_many(:user_groups).class_name('UserGroup') }
     it { should belong_to(:judicial_result).class_name('JudicialResult').optional }
@@ -12,9 +18,6 @@ RSpec.describe JudicialResultPrompt, type: :model do
     it { should validate_inclusion_of(:isAvailableForCourtExtract).in_array([true, false]) }
   end
 
-  let(:judicial_result_prompt) { FactoryBot.create(:judicial_result_prompt) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(judicial_result_prompt.to_builder.target!).to match_json_schema(:judicial_result_prompt)
-  end
 end

--- a/spec/models/judicial_role_spec.rb
+++ b/spec/models/judicial_role_spec.rb
@@ -17,5 +17,4 @@ RSpec.describe JudicialRole, type: :model do
   it { should validate_presence_of(:judicial_role_type) }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/judicial_role_spec.rb
+++ b/spec/models/judicial_role_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe JudicialRole, type: :model do
+  let(:judicial_role) { FactoryBot.create(:judicial_role) }
+
+  let(:json_schema) { :judicial_role }
+
+  subject { judicial_role }
+
   describe 'associations' do
     it { should belong_to(:next_hearing).class_name('NextHearing').optional }
   end
@@ -10,9 +16,6 @@ RSpec.describe JudicialRole, type: :model do
   it { should validate_presence_of(:judicialId) }
   it { should validate_presence_of(:judicial_role_type) }
 
-  let(:judicial_role) { FactoryBot.create(:judicial_role) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(judicial_role.to_builder.target!).to match_json_schema(:judicial_role)
-  end
 end

--- a/spec/models/judicial_role_type_spec.rb
+++ b/spec/models/judicial_role_type_spec.rb
@@ -11,5 +11,4 @@ RSpec.describe JudicialRoleType, type: :model do
   it { should validate_presence_of(:judiciaryType) }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/judicial_role_type_spec.rb
+++ b/spec/models/judicial_role_type_spec.rb
@@ -3,11 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe JudicialRoleType, type: :model do
+  let(:judicial_role_type) { FactoryBot.create(:judicial_role_type) }
+  let(:json_schema) { :judicial_role_type }
+
+  subject { judicial_role_type }
+
   it { should validate_presence_of(:judiciaryType) }
 
-  let(:judicial_role_type) { FactoryBot.create(:judicial_role_type) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(judicial_role_type.to_builder.target!).to match_json_schema(:judicial_role_type)
-  end
 end

--- a/spec/models/jurors_spec.rb
+++ b/spec/models/jurors_spec.rb
@@ -3,15 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Jurors, type: :model do
+  let(:jurors) { FactoryBot.create(:jurors) }
+
+  let(:json_schema) { :jurors }
+
+  subject { jurors }
+
   describe 'validations' do
     it { should validate_presence_of(:numberOfJurors) }
     it { should validate_presence_of(:numberOfSplitJurors) }
     it { should validate_inclusion_of(:unanimous).in_array([true, false]) }
   end
 
-  let(:jurors) { FactoryBot.create(:jurors) }
-
-  it 'matches the given schema' do
-    expect(jurors.to_builder.target!).to match_json_schema(:jurors)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe LaaReference, type: :model do
+  let(:laa_reference) { FactoryBot.create(:laa_reference) }
+
+  let(:json_schema) { :laa_reference }
+
+  subject { laa_reference }
+
   describe 'validations' do
     it { should validate_presence_of(:applicationReference) }
     it { should validate_presence_of(:statusId) }
@@ -11,9 +17,5 @@ RSpec.describe LaaReference, type: :model do
     it { should validate_presence_of(:statusDate) }
   end
 
-  let(:laa_reference) { FactoryBot.create(:laa_reference) }
-
-  it 'matches the given schema' do
-    expect(laa_reference.to_builder.target!).to match_json_schema(:laa_reference)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/legal_entity_defendant_spec.rb
+++ b/spec/models/legal_entity_defendant_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe LegalEntityDefendant, type: :model do
+  let(:legal_entity_defendant) { FactoryBot.create(:legal_entity_defendant) }
+
+  let(:json_schema) { :legal_entity_defendant }
+
+  subject { legal_entity_defendant }
+
   describe 'associations' do
     it { should belong_to(:organisation).class_name('Organisation') }
   end
@@ -11,10 +17,6 @@ RSpec.describe LegalEntityDefendant, type: :model do
   end
 
   context 'hmcts schema' do
-    let(:legal_entity_defendant) { FactoryBot.create(:legal_entity_defendant) }
-
-    it 'matches the given schema' do
-      expect(legal_entity_defendant.to_builder.target!).to match_json_schema(:legal_entity_defendant)
-    end
+  it_has_behaviour 'conforming to valid schema'
   end
 end

--- a/spec/models/legal_entity_defendant_spec.rb
+++ b/spec/models/legal_entity_defendant_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe LegalEntityDefendant, type: :model do
   end
 
   context 'hmcts schema' do
-  it_has_behaviour 'conforming to valid schema'
+    it_has_behaviour 'conforming to valid schema'
   end
 end

--- a/spec/models/lesser_or_alternative_offence_spec.rb
+++ b/spec/models/lesser_or_alternative_offence_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe LesserOrAlternativeOffence, type: :model do
+  let(:lesser_or_alternative_offence) { FactoryBot.create(:lesser_or_alternative_offence) }
+
+  let(:json_schema) { :lesser_or_alternative_offence }
+
+  subject { lesser_or_alternative_offence }
+
   describe 'validations' do
     it { should validate_presence_of(:offenceDefinitionId) }
     it { should validate_presence_of(:offenceCode) }
@@ -10,9 +16,6 @@ RSpec.describe LesserOrAlternativeOffence, type: :model do
     it { should validate_presence_of(:offenceLegislation) }
   end
 
-  let(:lesser_or_alternative_offence) { FactoryBot.create(:lesser_or_alternative_offence) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(lesser_or_alternative_offence.to_builder.target!).to match_json_schema(:lesser_or_alternative_offence)
-  end
 end

--- a/spec/models/lesser_or_alternative_offence_spec.rb
+++ b/spec/models/lesser_or_alternative_offence_spec.rb
@@ -17,5 +17,4 @@ RSpec.describe LesserOrAlternativeOffence, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/linked_defendant_spec.rb
+++ b/spec/models/linked_defendant_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe LinkedDefendant, type: :model do
+  let(:linked_defendant) { FactoryBot.create(:linked_defendant) }
+
+  let(:json_schema) { :linked_defendant }
+
+  subject { linked_defendant }
+
   describe 'validations' do
     it { should validate_presence_of(:prosecutionCaseId) }
     it { should validate_presence_of(:defendantId) }
   end
 
-  let(:linked_defendant) { FactoryBot.create(:linked_defendant) }
-
-  it 'matches the given schema' do
-    expect(linked_defendant.to_builder.target!).to match_json_schema(:linked_defendant)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Marker, type: :model do
+  let(:marker) { FactoryBot.create(:marker) }
+
+  let(:json_schema) { :marker }
+
+  subject { marker }
+
   describe 'validations' do
     it { should validate_presence_of(:markerTypeid) }
     it { should validate_presence_of(:markerTypeCode) }
@@ -10,9 +16,5 @@ RSpec.describe Marker, type: :model do
     it { should validate_presence_of(:markerTypeName) }
   end
 
-  let(:marker) { FactoryBot.create(:marker) }
-
-  it 'matches the given schema' do
-    expect(marker.to_builder.target!).to match_json_schema(:marker)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/merged_prosecution_case_spec.rb
+++ b/spec/models/merged_prosecution_case_spec.rb
@@ -5,9 +5,16 @@ require 'rails_helper'
 RSpec.describe MergedProsecutionCase, type: :model do
   let(:merged_prosecution_case) { FactoryBot.create(:merged_prosecution_case) }
 
+  let(:json_schema) { :merged_prosecution_case }
+
+  subject { merged_prosecution_case }
+
+  let(:merged_prosecution_case) { FactoryBot.create(:merged_prosecution_case) }
+
   describe 'associations' do
     it { should have_many(:merged_prosecution_case_targets).class_name('MergedProsecutionCaseTarget') }
   end
+
   describe 'validations' do
     it { should validate_presence_of(:prosecutionCaseReference) }
     it { should validate_presence_of(:merged_prosecution_case_targets) }
@@ -32,7 +39,5 @@ RSpec.describe MergedProsecutionCase, type: :model do
     end
   end
 
-  it 'matches the given schema' do
-    expect(merged_prosecution_case.to_builder.target!).to match_json_schema(:merged_prosecution_case)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/merged_prosecution_case_target_spec.rb
+++ b/spec/models/merged_prosecution_case_target_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe MergedProsecutionCaseTarget, type: :model do
+  let(:merged_prosecution_case_target) { FactoryBot.create(:merged_prosecution_case_target) }
+
+  let(:json_schema) { :merged_prosecution_case_target }
+
+  subject { merged_prosecution_case_target }
+
   describe 'validations' do
     it { should validate_presence_of(:prosecutionCaseId) }
     it { should validate_presence_of(:prosecutionCaseReference) }
   end
 
-  let(:merged_prosecution_case_target) { FactoryBot.create(:merged_prosecution_case_target) }
-
-  it 'matches the given schema' do
-    expect(merged_prosecution_case_target.to_builder.target!).to match_json_schema(:merged_prosecution_case_target)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/next_hearing_defendant_spec.rb
+++ b/spec/models/next_hearing_defendant_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe NextHearingDefendant, type: :model do
+  let(:next_hearing_defendant) { FactoryBot.create(:next_hearing_defendant) }
+
+  let(:json_schema) { :next_hearing_defendant }
+
+  subject { next_hearing_defendant }
+
   describe 'associations' do
     it { should have_many(:next_hearing_offences).class_name('NextHearingOffence') }
   end
@@ -11,9 +17,5 @@ RSpec.describe NextHearingDefendant, type: :model do
     it { should validate_presence_of(:next_hearing_offences) }
   end
 
-  let(:next_hearing_defendant) { FactoryBot.create(:next_hearing_defendant) }
-
-  it 'matches the given schema' do
-    expect(next_hearing_defendant.to_builder.target!).to match_json_schema(:next_hearing_defendant)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/next_hearing_offence_spec.rb
+++ b/spec/models/next_hearing_offence_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe NextHearingOffence, type: :model do
+  let(:next_hearing_offence) { FactoryBot.create(:next_hearing_offence) }
+
+  let(:json_schema) { :next_hearing_offence }
+
+  subject { next_hearing_offence }
+
   describe 'associations' do
     it { should belong_to(:next_hearing_defendant).class_name('NextHearingDefendant').optional }
   end
 
-  let(:next_hearing_offence) { FactoryBot.create(:next_hearing_offence) }
-
-  it 'matches the given schema' do
-    expect(next_hearing_offence.to_builder.target!).to match_json_schema(:next_hearing_offence)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/next_hearing_prosecution_case_spec.rb
+++ b/spec/models/next_hearing_prosecution_case_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe NextHearingProsecutionCase, type: :model do
+  let(:next_hearing_prosecution_case) { FactoryBot.create(:next_hearing_prosecution_case) }
+
+  let(:json_schema) { :next_hearing_prosecution_case }
+
+  subject { next_hearing_prosecution_case }
+
   describe 'associations' do
     it { should have_many(:next_hearing_defendants).class_name('NextHearingDefendant') }
     it { should belong_to(:next_hearing).class_name('NextHearing').optional }
@@ -12,9 +18,6 @@ RSpec.describe NextHearingProsecutionCase, type: :model do
     it { should validate_presence_of(:next_hearing_defendants) }
   end
 
-  let(:next_hearing_prosecution_case) { FactoryBot.create(:next_hearing_prosecution_case) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(next_hearing_prosecution_case.to_builder.target!).to match_json_schema(:next_hearing_prosecution_case)
-  end
 end

--- a/spec/models/next_hearing_prosecution_case_spec.rb
+++ b/spec/models/next_hearing_prosecution_case_spec.rb
@@ -19,5 +19,4 @@ RSpec.describe NextHearingProsecutionCase, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/next_hearing_spec.rb
+++ b/spec/models/next_hearing_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe NextHearing, type: :model do
+  let(:next_hearing) { FactoryBot.create(:next_hearing) }
+
+  let(:json_schema) { :next_hearing }
+
+  subject { next_hearing }
+
   describe 'associations' do
     it { should have_many(:judicial_roles).class_name('JudicialRole') }
     it { should have_many(:next_hearing_prosecution_cases).class_name('NextHearingProsecutionCase') }
@@ -23,9 +29,5 @@ RSpec.describe NextHearing, type: :model do
     end
   end
 
-  let(:next_hearing) { FactoryBot.create(:next_hearing) }
-
-  it 'matches the given schema' do
-    expect(next_hearing.to_builder.target!).to match_json_schema(:next_hearing)
-  end
+  it_has_behaviour 'conforming to valid schema'
 end

--- a/spec/models/notified_plea_spec.rb
+++ b/spec/models/notified_plea_spec.rb
@@ -20,5 +20,4 @@ RSpec.describe NotifiedPlea, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/notified_plea_spec.rb
+++ b/spec/models/notified_plea_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe NotifiedPlea, type: :model do
+  let(:notified_plea) { FactoryBot.create(:notified_plea) }
+
+  let(:json_schema) { :notified_plea }
+
+  subject { notified_plea }
+
   describe 'validations' do
     it { should validate_presence_of(:offenceId) }
     it { should validate_presence_of(:notifiedPleaDate) }
@@ -13,9 +19,6 @@ RSpec.describe NotifiedPlea, type: :model do
     end
   end
 
-  let(:notified_plea) { FactoryBot.create(:notified_plea) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(notified_plea.to_builder.target!).to match_json_schema(:notified_plea)
-  end
 end

--- a/spec/models/offence_facts_spec.rb
+++ b/spec/models/offence_facts_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe OffenceFacts, type: :model do
+  let(:offence_facts) { FactoryBot.create(:offence_facts) }
+  let(:json_schema) { :offence_facts }
+
+  subject { offence_facts }
+
   describe 'validations' do
     it do
       should validate_inclusion_of(:vehicleCode)
@@ -10,9 +15,6 @@ RSpec.describe OffenceFacts, type: :model do
     end
   end
 
-  let(:offence_facts) { FactoryBot.create(:offence_facts) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(offence_facts.to_builder.target!).to match_json_schema(:offence_facts)
-  end
 end

--- a/spec/models/offence_facts_spec.rb
+++ b/spec/models/offence_facts_spec.rb
@@ -16,5 +16,4 @@ RSpec.describe OffenceFacts, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Offence, type: :model do
+  let(:offence) { FactoryBot.create(:offence) }
+  let(:json_schema) { :offence }
+
+  subject { offence }
+
   describe 'associations' do
     it { should belong_to(:notified_plea).class_name('NotifiedPlea').optional }
     it { should belong_to(:indicated_plea).class_name('IndicatedPlea').optional }
@@ -27,9 +32,7 @@ RSpec.describe Offence, type: :model do
   context 'hmcts schema' do
     let(:offence) { FactoryBot.create(:offence) }
 
-    it 'matches the given schema' do
-      expect(offence.to_builder.target!).to match_json_schema(:offence)
-    end
+    it_has_behaviour 'conforming to valid schema'
 
     context 'with relationships' do
       before do
@@ -39,9 +42,8 @@ RSpec.describe Offence, type: :model do
         offence.save!
       end
 
-      it 'matches the given schema' do
-        expect(offence.to_builder.target!).to match_json_schema(:offence)
-      end
+      it_has_behaviour 'conforming to valid schema'
+
     end
   end
 end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Offence, type: :model do
       end
 
       it_has_behaviour 'conforming to valid schema'
-
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
+  let(:organisation) { FactoryBot.create(:organisation) }
+  let(:json_schema) { :organisation }
+
+  subject { organisation }
+
   describe 'associations' do
     it { should belong_to(:address).class_name('Address').optional }
     it { should belong_to(:contact).class_name('ContactNumber').optional }
@@ -11,9 +16,6 @@ RSpec.describe Organisation, type: :model do
     it { should validate_presence_of(:name) }
   end
 
-  let(:organisation) { FactoryBot.create(:organisation) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(organisation.to_builder.target!).to match_json_schema(:organisation)
-  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -17,5 +17,4 @@ RSpec.describe Organisation, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/person_defendant_spec.rb
+++ b/spec/models/person_defendant_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe PersonDefendant, type: :model do
+  let(:person_defendant) { FactoryBot.create(:person_defendant) }
+  let(:json_schema) { :person_defendant }
+
+  subject { person_defendant }
+
   describe 'associations' do
     it { should belong_to(:person).class_name('Person') }
     it { should belong_to(:bail_status).class_name('BailStatus').optional }
@@ -17,20 +22,16 @@ RSpec.describe PersonDefendant, type: :model do
   end
 
   context 'hmcts schema' do
-    let(:person_defendant) { FactoryBot.create(:person_defendant) }
 
-    it 'matches the given schema' do
-      expect(person_defendant.to_builder.target!).to match_json_schema(:person_defendant)
-    end
+    it_has_behaviour 'conforming to valid schema'
 
     context 'with relationships' do
       before do
         person_defendant.update! bail_status: FactoryBot.create(:bail_status), employer_organisation: FactoryBot.create(:organisation)
       end
 
-      it 'matches the given schema' do
-        expect(person_defendant.to_builder.target!).to match_json_schema(:person_defendant)
-      end
+     it_has_behaviour 'conforming to valid schema'
+
     end
   end
 end

--- a/spec/models/person_defendant_spec.rb
+++ b/spec/models/person_defendant_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe PersonDefendant, type: :model do
   end
 
   context 'hmcts schema' do
-
     it_has_behaviour 'conforming to valid schema'
 
     context 'with relationships' do
@@ -30,8 +29,7 @@ RSpec.describe PersonDefendant, type: :model do
         person_defendant.update! bail_status: FactoryBot.create(:bail_status), employer_organisation: FactoryBot.create(:organisation)
       end
 
-     it_has_behaviour 'conforming to valid schema'
-
+      it_has_behaviour 'conforming to valid schema'
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
+  let(:person) { FactoryBot.create(:person) }
+  let(:json_schema) { :person }
+
+  subject { person }
+
   describe 'associations' do
     it { should belong_to(:ethnicity).class_name('Ethnicity').optional }
     it { should belong_to(:address).class_name('Address').optional }
@@ -27,9 +32,6 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  let(:person) { FactoryBot.create(:person) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(person.to_builder.target!).to match_json_schema(:person)
-  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -33,5 +33,4 @@ RSpec.describe Person, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/plea_spec.rb
+++ b/spec/models/plea_spec.rb
@@ -20,5 +20,4 @@ RSpec.describe Plea, type: :model do
   it { should belong_to(:delegated_powers).class_name('DelegatedPowers').optional }
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/plea_spec.rb
+++ b/spec/models/plea_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Plea, type: :model do
+  let(:plea) { FactoryBot.create(:plea) }
+  let(:json_schema) { :plea }
+
+  subject { plea }
+
   it { should validate_presence_of(:originatingHearingId) }
   it { should validate_presence_of(:offenceId) }
   it { should validate_presence_of(:pleaDate) }
@@ -14,9 +19,6 @@ RSpec.describe Plea, type: :model do
 
   it { should belong_to(:delegated_powers).class_name('DelegatedPowers').optional }
 
-  let(:plea) { FactoryBot.create(:plea) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(plea.to_builder.target!).to match_json_schema(:plea)
-  end
 end

--- a/spec/models/police_officer_in_case_spec.rb
+++ b/spec/models/police_officer_in_case_spec.rb
@@ -19,5 +19,4 @@ RSpec.describe PoliceOfficerInCase, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/police_officer_in_case_spec.rb
+++ b/spec/models/police_officer_in_case_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe PoliceOfficerInCase, type: :model do
+  let(:police_officer_in_case) { FactoryBot.create(:police_officer_in_case) }
+  let(:json_schema) { :police_officer_in_case }
+
+  subject { police_officer_in_case }
+
   describe 'associations' do
     it { should belong_to(:person).class_name('Person').required }
   end
@@ -13,9 +18,6 @@ RSpec.describe PoliceOfficerInCase, type: :model do
     it { should validate_presence_of(:policeWorkerLocationCode) }
   end
 
-  let(:police_officer_in_case) { FactoryBot.create(:police_officer_in_case) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(police_officer_in_case.to_builder.target!).to match_json_schema(:police_officer_in_case)
-  end
 end

--- a/spec/models/prosecution_case_identifier_spec.rb
+++ b/spec/models/prosecution_case_identifier_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe ProsecutionCaseIdentifier, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/prosecution_case_identifier_spec.rb
+++ b/spec/models/prosecution_case_identifier_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe ProsecutionCaseIdentifier, type: :model do
+  let(:prosecution_case_identifier) { FactoryBot.create(:prosecution_case_identifier) }
+  let(:json_schema) { :prosecution_case_identifier }
+
+  subject { prosecution_case_identifier }
+
   describe 'validations' do
     it { should validate_presence_of(:prosecutionAuthorityId) }
     it { should validate_presence_of(:prosecutionAuthorityCode) }
   end
 
-  let(:prosecution_case_identifier) { FactoryBot.create(:prosecution_case_identifier) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(prosecution_case_identifier.to_builder.target!).to match_json_schema(:prosecution_case_identifier)
-  end
 end

--- a/spec/models/verdict_spec.rb
+++ b/spec/models/verdict_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Verdict, type: :model do
+  let(:verdict) { FactoryBot.create(:verdict) }
+  let(:json_schema) { :verdict }
+
+  subject { verdict }
+
   describe 'associations' do
     it { should belong_to(:verdict_type).class_name('VerdictType') }
     it { should belong_to(:jurors).class_name('Jurors').optional }
@@ -16,9 +21,6 @@ RSpec.describe Verdict, type: :model do
     it { should validate_presence_of(:verdict_type) }
   end
 
-  let(:verdict) { FactoryBot.create(:verdict) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(verdict.to_builder.target!).to match_json_schema(:verdict)
-  end
 end

--- a/spec/models/verdict_spec.rb
+++ b/spec/models/verdict_spec.rb
@@ -22,5 +22,4 @@ RSpec.describe Verdict, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end

--- a/spec/models/verdict_type_spec.rb
+++ b/spec/models/verdict_type_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe VerdictType, type: :model do
+  let(:verdict_type) { FactoryBot.create(:verdict_type) }
+  let(:json_schema) { :verdict_type }
+
+  subject { verdict_type }
+
   describe 'validations' do
     it { should validate_presence_of(:category) }
     it { should validate_presence_of(:categoryType) }
   end
 
-  let(:verdict_type) { FactoryBot.create(:verdict_type) }
+  it_has_behaviour 'conforming to valid schema'
 
-  it 'matches the given schema' do
-    expect(verdict_type.to_builder.target!).to match_json_schema(:verdict_type)
-  end
 end

--- a/spec/models/verdict_type_spec.rb
+++ b/spec/models/verdict_type_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe VerdictType, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
-
 end


### PR DESCRIPTION
refactors model `specs` to use common shared example for matching to schemas.