### PR TITLE
Search Prosecution Cases by prosecutionCaseReference

### DIFF
--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -4,6 +4,7 @@ class ProsecutionCaseSearch < ApplicationService
   def initialize(params)
     @params = params
     @schema = JSON.parse(File.open(Rails.root.join('lib/schemas/api/search-prosecutionCaseRequest.json')).read)
+    normalise_schema!
   end
 
   def call
@@ -19,5 +20,11 @@ class ProsecutionCaseSearch < ApplicationService
 
   def permitted_params
     params.permit(schema['properties'].keys)
+  end
+
+  def normalise_schema!
+    # Since courtsDefinitions.json does not map to the expected directory structure for both the api responses and the model schemas,
+    # we are overriding the id, to ensure that the validator can find the definitions without blowing up.
+    schema['id'] = 'lib/schemas/api/global/'
   end
 end

--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -11,12 +11,18 @@ class ProsecutionCaseSearch < ApplicationService
     errors = JSON::Validator.fully_validate(schema, permitted_params.to_json)
     raise Errors::InvalidParams, errors if errors.present?
 
-    ProsecutionCase.all
+    prosecution_cases_by_reference if permitted_params['prosecutionCaseReference'].present?
   end
 
   private
 
   attr_reader :params, :schema
+
+  def prosecution_cases_by_reference
+    ProsecutionCase
+      .joins(:prosecution_case_identifier)
+      .where('"caseURN" = :search OR "prosecutionAuthorityReference" = :search', search: permitted_params['prosecutionCaseReference'])
+  end
 
   def permitted_params
     params.permit(schema['properties'].keys)

--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -4,14 +4,16 @@ class ProsecutionCaseSearch < ApplicationService
   def initialize(params)
     @params = params
     @schema = JSON.parse(File.open(Rails.root.join('lib/schemas/api/search-prosecutionCaseRequest.json')).read)
-    normalise_schema!
+    register_dependant_schemas!
   end
 
   def call
     errors = JSON::Validator.fully_validate(schema, permitted_params.to_json)
     raise Errors::InvalidParams, errors if errors.present?
 
-    prosecution_cases_by_reference if permitted_params['prosecutionCaseReference'].present?
+    return prosecution_cases_by_reference if permitted_params['prosecutionCaseReference'].present?
+
+    prosecution_cases_by_nino if permitted_params['nationalInsuranceNumber'].present?
   end
 
   private
@@ -21,16 +23,30 @@ class ProsecutionCaseSearch < ApplicationService
   def prosecution_cases_by_reference
     ProsecutionCase
       .joins(:prosecution_case_identifier)
-      .where('"caseURN" = :search OR "prosecutionAuthorityReference" = :search', search: permitted_params['prosecutionCaseReference'])
+      .where('"caseURN" = :search OR "prosecutionAuthorityReference" = :search', search: permitted_params[:prosecutionCaseReference])
+  end
+
+  def prosecution_cases_by_nino
+    ProsecutionCase.joins(:defendants).where(defendants: { defendable_type: 'PersonDefendant', defendable_id: person_defendant_by_nino })
+  end
+
+  def person_defendant_by_nino
+    PersonDefendant.joins(:person).where(people: { nationalInsuranceNumber: permitted_params[:nationalInsuranceNumber] })
   end
 
   def permitted_params
     params.permit(schema['properties'].keys)
   end
 
-  def normalise_schema!
+  def register_dependant_schemas!
     # Since courtsDefinitions.json does not map to the expected directory structure for both the api responses and the model schemas,
     # we are overriding the id, to ensure that the validator can find the definitions without blowing up.
-    schema['id'] = 'lib/schemas/api/global/'
+    courts_definitions = JSON.parse(File.open(Rails.root.join('lib/schemas/global/courtsDefinitions.json')).read)
+    courts_definitions['id'] = 'http://justice.gov.uk/unified_search_query/global/courtsDefinitions.json'
+    JSON::Validator.add_schema(JSON::Schema.new(courts_definitions, Addressable::URI.parse(courts_definitions['id'])))
+
+    defendant_name = JSON.parse(File.open(Rails.root.join('lib/schemas/global/search/defendantName.json')).read)
+    defendant_name['id'] = 'http://justice.gov.uk/unified_search_query/global/search/defendantName.json'
+    JSON::Validator.add_schema(JSON::Schema.new(defendant_name, Addressable::URI.parse(defendant_name['id'])))
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,5 @@
 Rails.application.routes.draw do
   resources :status, only: [:index]
 
-  defaults format: :json do
-    resources :prosecution_cases, path: 'prosecutionCases', only: [:index]
-  end
+  resources :prosecution_cases, path: 'prosecutionCases', only: [:index]
 end

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'ProsecutionCases', type: :request do
   describe 'GET /prosecution_cases' do
-    let!(:prosecution_case) { FactoryBot.create(:prosecution_case) }
+    let!(:prosecution_case) do
+      FactoryBot.create(:prosecution_case,
+                        prosecution_case_identifier: FactoryBot.create(:prosecution_case_identifier,
+                                                                       caseURN: 'some-reference'))
+    end
 
     it 'matches the response schema' do
       get '/prosecutionCases?prosecutionCaseReference=some-reference'

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -3,27 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe ProsecutionCaseSearch do
+  let(:params) { ActionController::Parameters.new(params_hash) }
+
   subject { described_class.call(params) }
 
-  let(:params) do
-    ActionController::Parameters.new(prosecutionCaseReference: 'some reference')
-  end
-
-  let!(:prosecution_case) { FactoryBot.create(:prosecution_case) }
-
-  it 'returns all ProsecutionCases' do
-    expect(subject).to eq([prosecution_case])
-  end
-
   context 'with invalid params' do
-    let(:params) do
-      ActionController::Parameters.new(random: 'value')
+    let(:params_hash) do
+      { random: 'value' }
     end
 
     it 'raises an invalid params error' do
       expect do
         subject
       end.to raise_error(Errors::InvalidParams)
+    end
+  end
+
+  context 'when searching by prosecutionCaseReference' do
+    let(:cases) { FactoryBot.build_list(:prosecution_case, 3) }
+
+    before do
+      cases.first.prosecution_case_identifier = FactoryBot.build(:prosecution_case_identifier,
+                                                                 caseURN: 'XXYYZZ')
+      cases.second.prosecution_case_identifier = FactoryBot.build(:prosecution_case_identifier_with_reference,
+                                                                  prosecutionAuthorityReference: 'XXYYZZ')
+      cases.map(&:save!)
+    end
+
+    let(:params_hash) do
+      { prosecutionCaseReference: 'XXYYZZ' }
+    end
+
+    it { is_expected.to include(cases.first) }
+    it { is_expected.to include(cases.second) }
+    it { is_expected.not_to include(cases.third) }
+
+    context 'with a non matching reference' do
+      let(:params_hash) do
+        { prosecutionCaseReference: 'NOT EXISTENT' }
+      end
+
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-
+# rubocop:disable Metrics/BlockLength
 RSpec.describe ProsecutionCaseSearch do
   let(:params) { ActionController::Parameters.new(params_hash) }
 
@@ -46,4 +46,35 @@ RSpec.describe ProsecutionCaseSearch do
       it { is_expected.to be_empty }
     end
   end
+
+  context 'when searching by nationalInsuranceNumber' do
+    let(:cases) { FactoryBot.create_list(:prosecution_case, 2) }
+    let(:defendant) do
+      FactoryBot.build(:defendant,
+                       prosecution_case: nil,
+                       defendable: FactoryBot.create(:person_defendant,
+                                                     person: FactoryBot.create(:person, nationalInsuranceNumber: 'NH489223C')))
+    end
+
+    before do
+      cases.first.defendants << defendant
+      cases.first.save!
+    end
+
+    let(:params_hash) do
+      { nationalInsuranceNumber: 'NH489223C' }
+    end
+
+    it { is_expected.to include(cases.first) }
+    it { is_expected.not_to include(cases.second) }
+
+    context 'with a non matching reference' do
+      let(:params_hash) do
+        { nationalInsuranceNumber: 'XJ812213C' }
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  config.before(:each) do
+  config.before(:each, type: ->(spec_type) { %i[model request].include? spec_type }) do
     stub_request(:any, /justice.gov.uk/).to_rack(FakeCommonPlatform)
   end
 end


### PR DESCRIPTION
### Summary
1. Run the webmocked specs only for model and request specs, and in other cases, (i.e, services) we rely on the local file paths to read and validate the json schemas. This is important as we are now using a schema to validate the request params as well, and we need to ensure that the specs are reflecting the actual use, rather than 'faking' a request.

2. This requires us to manually register additonal ref schemas, to ensure that the json-schema validator can find the references relative to the given schema.

3. ProsecutionCases can be queried by either
  a) prosecutionCaseReference,
  b) nationalInsuranceNumber,
  c) arrestSummonsNumber,
  d) name and dateOfBirth, or
  e) name and dateOfNextHearing
This PR handles a) prosecutionCaseReference and b) nationalInsuranceNumber

#### Assumptions

We are assuming that prosecutionCaseReference could be one of `caseURN` or `prosecutionAuthorityReference`, defined on the `ProsecutionCaseIdentifier`
