### PR TITLE
Add prosecution case search params

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -12,10 +12,25 @@ class Defendant < ApplicationRecord
   has_many :split_prosecutor_case_references
   has_many :linked_defendants
 
+  belongs_to :person_defendant,
+             -> { where(defendants: { defendable_type: 'PersonDefendant' }) },
+             class_name: 'PersonDefendant',
+             foreign_key: 'defendable_id',
+             optional: true
+
+  belongs_to :legal_entity_defendant,
+             -> { where(defendants: { defendable_type: 'LegalEntityDefendant' }) },
+             class_name: 'LegalEntityDefendant',
+             foreign_key: 'defendable_id',
+             optional: true
+
   validates :prosecution_case, presence: true
   validates :offences, presence: true
   validates :defendable, presence: true
   validates :split_prosecutor_case_references, length: { minimum: 2 }, if: -> { split_prosecutor_case_references.present? }
+
+  scope :people_only, -> { joins(:person_defendant) }
+  scope :legal_entity_only, -> { joins(:legal_entity_defendant) }
 
   def person?
     defendable.is_a? PersonDefendant

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,6 +5,9 @@ class Person < ApplicationRecord
   GENDERS = %w[MALE FEMALE NOT_KNOWN NOT_SPECIFIED].freeze
   TITLES = %w[MR MRS MISS MS].freeze
 
+  scope :by_name, ->(full_name) { where(full_name.slice(:firstName, :lastName, :middleName)) }
+  scope :by_date_of_birth, ->(date) { where(dateOfBirth: date) }
+
   belongs_to :ethnicity, optional: true
   belongs_to :address, optional: true
   belongs_to :contact_number, optional: true

--- a/app/models/person_defendant.rb
+++ b/app/models/person_defendant.rb
@@ -8,6 +8,8 @@ class PersonDefendant < ApplicationRecord
   validates :person, presence: true
   validates :driverLicenceCode, inclusion: %w[FULL PROVISIONAL]
 
+  scope :by_name_and_dob, ->(params) { joins(:person).merge(Person.by_name(params[:name]).by_date_of_birth(params[:dateOfBirth])) }
+
   def to_builder
     Jbuilder.new do |person_defendant|
       person_defendant.personDetails person.to_builder

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -10,6 +10,8 @@ class ProsecutionCase < ApplicationRecord
   belongs_to :hearing, optional: true, inverse_of: :prosecution_cases
 
   has_many :defendants
+  has_many :person_only_defendants, -> { people_only }, class_name: 'Defendant'
+  has_many :legal_entity_only_defendants, -> { legal_entity_only }, class_name: 'Defendant'
   has_many :markers
   has_many :split_prosecutor_case_references
   has_many :linked_prosecution_cases

--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -13,7 +13,9 @@ class ProsecutionCaseSearch < ApplicationService
 
     return prosecution_cases_by_reference if permitted_params['prosecutionCaseReference'].present?
 
-    prosecution_cases_by_nino if permitted_params['nationalInsuranceNumber'].present?
+    return prosecution_cases_by_nino if permitted_params['nationalInsuranceNumber'].present?
+
+    prosecution_cases_by_summons if permitted_params['arrestSummonsNumber'].present?
   end
 
   private
@@ -32,6 +34,14 @@ class ProsecutionCaseSearch < ApplicationService
 
   def person_defendant_by_nino
     PersonDefendant.joins(:person).where(people: { nationalInsuranceNumber: permitted_params[:nationalInsuranceNumber] })
+  end
+
+  def prosecution_cases_by_summons
+    ProsecutionCase.joins(:defendants).where(defendants: { defendable_type: 'PersonDefendant', defendable_id: person_defendant_by_summons })
+  end
+
+  def person_defendant_by_summons
+    PersonDefendant.where(arrestSummonsNumber: permitted_params[:arrestSummonsNumber])
   end
 
   def permitted_params

--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -31,7 +31,7 @@ class ProsecutionCaseSearch < ApplicationService
   end
 
   def prosecution_cases_by_nino
-    ProsecutionCase.joins(:defendants).where(defendants: { defendable_type: 'PersonDefendant', defendable_id: person_defendant_by_nino })
+    ProsecutionCase.joins(person_only_defendants: :person_defendant).merge(person_defendant_by_nino)
   end
 
   def person_defendant_by_nino
@@ -39,7 +39,7 @@ class ProsecutionCaseSearch < ApplicationService
   end
 
   def prosecution_cases_by_summons
-    ProsecutionCase.joins(:defendants).where(defendants: { defendable_type: 'PersonDefendant', defendable_id: person_defendant_by_summons })
+    ProsecutionCase.joins(person_only_defendants: :person_defendant).merge(person_defendant_by_summons)
   end
 
   def person_defendant_by_summons
@@ -47,10 +47,7 @@ class ProsecutionCaseSearch < ApplicationService
   end
 
   def prosecution_cases_by_name_and_dob
-    ProsecutionCase.joins(:defendants).where(defendants: {
-                                               defendable_type: 'PersonDefendant',
-                                               defendable_id: person_defendant_by_name_and_dob
-                                             })
+    ProsecutionCase.joins(person_only_defendants: :person_defendant).merge(person_defendant_by_name_and_dob)
   end
 
   def person_defendant_by_name_and_dob

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -9,8 +9,29 @@ RSpec.describe Defendant, type: :model do
 
   subject { defendant }
 
+  describe 'scopes' do
+    let!(:defendant_as_person) { FactoryBot.create(:defendant) }
+    let!(:defendant_as_legal_entity) { FactoryBot.create(:defendant_as_legal_entity) }
+
+    describe '.people_only' do
+      subject { described_class.people_only }
+
+      it { is_expected.to include(defendant_as_person) }
+      it { is_expected.not_to include(defendant_as_legal_entity) }
+    end
+
+    describe '.legal_entity_only' do
+      subject { described_class.legal_entity_only }
+
+      it { is_expected.not_to include(defendant_as_person) }
+      it { is_expected.to include(defendant_as_legal_entity) }
+    end
+  end
+
   describe 'associations' do
     it { should belong_to(:defendable) }
+    it { should belong_to(:person_defendant).class_name('PersonDefendant').optional }
+    it { should belong_to(:legal_entity_defendant).class_name('LegalEntityDefendant').optional }
     it { should belong_to(:prosecution_case).class_name('ProsecutionCase') }
     it { should have_many(:offences).class_name('Offence') }
     it { should have_many(:associated_people).class_name('AssociatedPerson') }

--- a/spec/models/person_defendant_spec.rb
+++ b/spec/models/person_defendant_spec.rb
@@ -2,11 +2,31 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe PersonDefendant, type: :model do
   let(:person_defendant) { FactoryBot.create(:person_defendant) }
   let(:json_schema) { :person_defendant }
 
   subject { person_defendant }
+
+  describe 'scopes' do
+    describe '.by_name_and_dob' do
+      let(:params) { { name: { firstName: 'John', lastName: 'Doe' }, dateOfBirth: '2000-05-12' } }
+
+      subject { described_class.by_name_and_dob(params) }
+
+      before do
+        allow(Person).to receive(:by_name).and_call_original
+        allow(Person).to receive(:by_date_of_birth).and_call_original
+      end
+
+      it 'calls the by_name and by_date_of_birth scopes on Person' do
+        expect(Person).to receive(:by_name).with(params[:name])
+        expect(Person).to receive(:by_date_of_birth).with(params[:dateOfBirth])
+        subject
+      end
+    end
+  end
 
   describe 'associations' do
     it { should belong_to(:person).class_name('Person') }
@@ -33,3 +53,4 @@ RSpec.describe PersonDefendant, type: :model do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe ProsecutionCase, type: :model do
     it { should belong_to(:police_officer_in_case).class_name('PoliceOfficerInCase').optional }
     it { should belong_to(:merged_prosecution_case).class_name('MergedProsecutionCase').optional }
     it { should have_many(:defendants).class_name('Defendant') }
+    it { should have_many(:person_only_defendants).class_name('Defendant') }
+    it { should have_many(:legal_entity_only_defendants).class_name('Defendant') }
     it { should have_many(:markers).class_name('Marker') }
     it { should have_many(:split_prosecutor_case_references).class_name('SplitProsecutorCaseReference') }
     it { should have_many(:linked_prosecution_cases).class_name('LinkedProsecutionCase') }

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ProsecutionCaseSearch do
 
     context 'with a non matching reference' do
       let(:params_hash) do
-        { prosecutionCaseReference: 'NOT EXISTENT' }
+        { prosecutionCaseReference: 'NON EXISTENT' }
       end
 
       it { is_expected.to be_empty }
@@ -71,6 +71,35 @@ RSpec.describe ProsecutionCaseSearch do
     context 'with a non matching reference' do
       let(:params_hash) do
         { nationalInsuranceNumber: 'XJ812213C' }
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  context 'when searching by arrestSummonsNumber' do
+    let(:cases) { FactoryBot.create_list(:prosecution_case, 2) }
+    let(:defendant) do
+      FactoryBot.build(:defendant,
+                       prosecution_case: nil,
+                       defendable: FactoryBot.create(:person_defendant, arrestSummonsNumber: '3.1428'))
+    end
+
+    before do
+      cases.first.defendants << defendant
+      cases.first.save!
+    end
+
+    let(:params_hash) do
+      { arrestSummonsNumber: '3.1428' }
+    end
+
+    it { is_expected.to include(cases.first) }
+    it { is_expected.not_to include(cases.second) }
+
+    context 'with a non matching reference' do
+      let(:params_hash) do
+        { arrestSummonsNumber: 'NON EXISTENT' }
       end
 
       it { is_expected.to be_empty }

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -105,5 +105,38 @@ RSpec.describe ProsecutionCaseSearch do
       it { is_expected.to be_empty }
     end
   end
+
+  context 'when searching by name and dateOfBirth' do
+    let(:cases) { FactoryBot.create_list(:prosecution_case, 2) }
+    let(:defendant) do
+      FactoryBot.build(:defendant,
+                       prosecution_case: nil,
+                       defendable: FactoryBot.create(:person_defendant,
+                                                     person: FactoryBot.create(:person,
+                                                                               firstName: 'John',
+                                                                               lastName: 'Doe',
+                                                                               dateOfBirth: '2000-01-10')))
+    end
+
+    before do
+      cases.first.defendants << defendant
+      cases.first.save!
+    end
+
+    let(:params_hash) do
+      { dateOfBirth: '2000-01-10', name: { firstName: 'John', lastName: 'Doe' } }
+    end
+
+    it { is_expected.to include(cases.first) }
+    it { is_expected.not_to include(cases.second) }
+
+    context 'with a non matching reference' do
+      let(:params_hash) do
+        { dateOfBirth: '2012-12-12', name: { firstName: 'John', lastName: 'Doe' } }
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Add functionality to allow searching by arrestSummonsNumber or DateOfBirth and Name.
The name is modelled on [defendantName.json](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/blob/4e216ae24c4596c9b0d4c4f7721f3fc57df33525/lib/schemas/global/search/defendantName.json), i.e, it expects `firstName`, `lastName` and optionally `middleName`