### PR TITLE
Get hearing results api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  rescue_from Errors::InvalidParams do |error|
-    render json: { error: error }, status: :bad_request
+  ERROR_MAPPINGS = {
+    Errors::InvalidParams => :bad_request,
+    ActiveRecord::RecordNotFound => :not_found
+  }.freeze
+
+  ERROR_MAPPINGS.each do |klass, status|
+    rescue_from klass do |error|
+      render json: { error: error }, status: status
+    end
   end
 end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class HearingsController < ApplicationController
+  def show
+    @hearing = Hearing.find(params[:id])
+    render json: { hearing: @hearing.to_builder.attributes! }
+  end
+end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -2,7 +2,8 @@
 
 class HearingsController < ApplicationController
   def show
-    @hearing = Hearing.find(params[:id])
+    @hearing = HearingFinder.call(params)
+
     render json: { hearing: @hearing.to_builder.attributes! }
   end
 end

--- a/app/services/hearing_finder.rb
+++ b/app/services/hearing_finder.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class HearingFinder < ApplicationService
+  def initialize(params)
+    @params = params
+    @schema = JSON.parse(File.open(Rails.root.join('lib/schemas/api/results.hearingResultedRequest.json')).read)
+    register_dependant_schemas!
+  end
+
+  def call
+    errors = JSON::Validator.fully_validate(schema, permitted_params.to_json)
+    raise Errors::InvalidParams, errors if errors.present?
+
+    Hearing.find(params[:hearingId])
+  end
+
+  private
+
+  attr_reader :params, :schema
+
+  def permitted_params
+    params.permit(:hearingId)
+  end
+
+  def register_dependant_schemas!
+    # Since courtsDefinitions.json does not map to the expected directory structure for both the api responses and the model schemas,
+    # we are overriding the id, to ensure that the validator can find the definitions without blowing up.
+    courts_definitions = JSON.parse(File.open(Rails.root.join('lib/schemas/global/courtsDefinitions.json')).read)
+    courts_definitions['id'] = 'http://justice.gov.uk/results/global/courtsDefinitions.json'
+    JSON::Validator.add_schema(JSON::Schema.new(courts_definitions, Addressable::URI.parse(courts_definitions['id'])))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   resources :status, only: [:index]
 
   resources :prosecution_cases, path: 'prosecutionCases', only: [:index]
-  resources :hearings, path: 'hearing/results', only: [:show]
+  resources :hearings, path: 'hearing/results', only: [:show], param: :hearingId
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   resources :status, only: [:index]
 
   resources :prosecution_cases, path: 'prosecutionCases', only: [:index]
+  resources :hearings, path: 'hearing/results', only: [:show]
 end

--- a/lib/schemas/api/hearing-resulted.json
+++ b/lib/schemas/api/hearing-resulted.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "http://justice.gov.uk/hearing/courts/api/hearing-resulted.json",
+	"type": "object",
+	"properties": {
+		"hearing": {
+			"$ref": "../../global/hearing.json#"
+		},
+		"sharedTime": {
+			"format": "date-time"
+		}
+	},
+	"required": [
+		"hearing",
+		"sharedTime"
+	],
+	"additionalProperties": false
+}

--- a/lib/schemas/api/progression.recordLAAReference.json
+++ b/lib/schemas/api/progression.recordLAAReference.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "http://justice.gov.uk/progression/courts/public/progression.recordLAAReference.json",
+	"description": "Records a reference to the legal aid application against the court case details",
+	"type": "object",
+	"properties": {
+		"prosecutionCaseId": {
+			"description": "The identifier of the prosecution case",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"defendantId": {
+			"description": "The identifier of the defendant",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"offenceId": {
+			"description": "The identifier of the offence",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"statusCode": {
+			"description": "The status of the application that aligns to the reference data",
+			"type": "string"
+		},
+		"applicationReference": {
+			"description": "The LAA issued reference to the application.  Currently known as the MAAT Id",
+			"type": "string"
+		},
+		"statusDate": {
+		  "description": "The date that the status was recorded",
+		  "$ref": "../../global/courtsDefinitions.json#/definitions/datePattern"
+		}
+	},
+	"required": [
+		"prosecutionCaseId", "defendantId", "offenceId", "statusCode", "applicationReference", "statusDate"
+	],
+	"additionalProperties": false
+}

--- a/lib/schemas/api/progression.recordRepresentationOrder.json
+++ b/lib/schemas/api/progression.recordRepresentationOrder.json
@@ -1,0 +1,48 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "http://justice.gov.uk/progression/courts/api/progression.recordRepresentationOrder.json",
+	"description": "Records the details of a representation order against the court case details.  Supports create and update command instructions",
+	"type": "object",
+	"properties": {
+		"prosecutionCaseId": {
+			"description": "The identifier of the prosecution case",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"defendantId": {
+			"description": "The identifier of the defendant",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"offenceId": {
+			"description": "The identifier of the offence",
+			"$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		},
+		"statusCode": {
+			"description": "The status of the application that aligns to the reference data",
+			"type": "string"
+		},
+		"applicationReference": {
+			"description": "The LAA issued reference to the application.  Currently known as the MAAT Id",
+			"type": "string"
+		},
+		"statusDate": {
+		  "description": "The date that the status was recorded",
+		  "$ref": "../../global/courtsDefinitions.json#/definitions/datePattern"
+		},
+		"effectiveStartDate": {
+		  "description": "The start date for legal aid",
+		  "$ref": "../../global/courtsDefinitions.json#/definitions/datePattern"
+		},
+		"effectiveEndDate": {
+		  "description": "The end date for legal aid",
+		  "$ref": "../../global/courtsDefinitions.json#/definitions/datePattern"
+		},
+		"defenceOrganisation": {
+		  "description": "The associated defence representation details",
+		  "$ref": "../../global/defenceOrganisation.json"
+		}
+	},
+	"required": [
+		"prosecutionCaseId", "defendantId", "offenceId", "statusCode", "applicationReference", "statusDate", "effectiveStartDate", "defenceOrganisation"
+	],
+	"additionalProperties": false
+}

--- a/lib/schemas/api/results.hearingResultedRequest.json
+++ b/lib/schemas/api/results.hearingResultedRequest.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "http://justice.gov.uk/results/courts/api/hearingResultedRequest.json",
+	"type": "object",
+	"properties": {
+		"hearingId": {
+		  "description": "The identifier of the resulted hearing",
+		  "$ref": "../../global/courtsDefinitions.json#/definitions/uuid"
+		}
+	},
+	"required": [
+		"hearingId"
+	  ],
+	"additionalProperties": false
+}

--- a/lib/schemas/api/results.hearingResultedResponse.json
+++ b/lib/schemas/api/results.hearingResultedResponse.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "http://justice.gov.uk/results/courts/api/hearingResultedResponse.json",
+	"type": "object",
+	"properties": {
+		"hearing": {
+			"description": "The details of the resulted hearing, its case details and the results",
+			"$ref": "../../global/hearing.json#"
+		},
+		"sharedTime": {
+			"description": "The date and time that teh results were shared by HMCTS",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+}

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe ApplicationController, type: :controller do
       expect(response).to have_http_status(:bad_request)
     end
   end
+
+  describe 'handling ActiveRecord::RecordNotFound' do
+    controller do
+      def index
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+
+    it 'returns http not_found' do
+      get :index
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingsController, type: :controller do
+  let(:hearing) { FactoryBot.create(:hearing) }
+  describe 'GET #show' do
+    it 'returns a success response' do
+      get :show, params: { id: hearing.id }
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HearingsController, type: :controller do
   let(:hearing) { FactoryBot.create(:hearing) }
   describe 'GET #show' do
     it 'returns a success response' do
-      get :show, params: { id: hearing.id }
+      get :show, params: { hearingId: hearing.id }
       expect(response).to be_successful
     end
   end

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Hearings', type: :request do
+  describe 'GET /hearing/results/:id' do
+    let(:hearing) { FactoryBot.create(:hearing) }
+
+    it 'matches the response schema' do
+      get "/hearing/results/#{hearing.id}"
+      expect(response).to have_http_status(200)
+      expect(response.body).to match_json_schema(:results_hearing_resulted_response)
+    end
+  end
+end

--- a/spec/services/hearing_finder_spec.rb
+++ b/spec/services/hearing_finder_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HearingFinder do
+  let(:params) { ActionController::Parameters.new(params_hash) }
+
+  subject { described_class.call(params) }
+
+  context 'with invalid params' do
+    let(:params_hash) do
+      { random: 'value' }
+    end
+
+    it 'raises an invalid params error' do
+      expect do
+        subject
+      end.to raise_error(Errors::InvalidParams)
+    end
+  end
+
+  context 'when finding by hearingId' do
+    let(:hearing) { FactoryBot.create(:hearing) }
+
+    let(:params_hash) do
+      { hearingId: hearing.id }
+    end
+
+    it { is_expected.to eq(hearing) }
+
+    context 'with an incorrect id' do
+      let(:params_hash) do
+        { hearingId: '6c0b7068-d4a7-4adc-a7a0-7bd5715b501d' }
+      end
+
+      it 'raises a RecordNotFound error' do
+        expect do
+          subject
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/support/fake_common_platform.rb
+++ b/spec/support/fake_common_platform.rb
@@ -27,6 +27,10 @@ class FakeCommonPlatform < Sinatra::Base
     json_response(200, '/global/', params[:file_name])
   end
 
+  get '/results/global/:file_name' do
+    json_response(200, '/global/', params[:file_name])
+  end
+
   private
 
   def json_response(response_code, file_path, file_name)

--- a/spec/support/schema_matchers.rb
+++ b/spec/support/schema_matchers.rb
@@ -88,5 +88,6 @@ RSpec.configure do |config|
 
   # Responses
   config.json_schemas[:search_prosecution_case_response] = "#{schema_path}/api/search-prosecutionCaseResponse.json"
+  config.json_schemas[:results_hearing_resulted_response] = "#{schema_path}/api/results.hearingResultedResponse.json"
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
A request can be made using the suggested URL of
`hearing/results/:hearingId`
Additionally, added a default error-handling mechanism to render a 404 in case of a non-existent ID.



