### PR TITLE
Enable Ingress to allow access from outside k8s

### DIFF
--- a/helm_deploy/hmcts-common-platform-mock-api/values.yaml
+++ b/helm_deploy/hmcts-common-platform-mock-api/values.yaml
@@ -18,13 +18,14 @@ service:
   port: 3000
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
-      paths: []
+    - host: hmcts-common-platform-mock-api.apps.live-1.cloud-platform.service.justice.gov.uk
+      paths:
+        - path: /
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
By allowing the access to the API from outside K8s we will be able to
test the API responses from developers machines.
In order to allow this, we need to enable the ingress in our service.