### PR TITLE
Fix Ingress path

### DIFF
--- a/helm_deploy/hmcts-common-platform-mock-api/values.yaml
+++ b/helm_deploy/hmcts-common-platform-mock-api/values.yaml
@@ -24,8 +24,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: hmcts-common-platform-mock-api.apps.live-1.cloud-platform.service.justice.gov.uk
-      paths:
-        - path: /
+      paths: ["/"]
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
Specifying the "path" key under "paths" instead of directly the path
values was being translated into "path:path:/" in the template.