### PR TITLE
Avoid spring from booting in production and require json-schema in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /usr/src/app
 COPY Gemfile* ./
 
 RUN gem install bundler -v 2.0.2 \
-&& bundle install --deployment
+&& bundle install --deployment --without development test
 
 ####################
 # DEPENDENCIES END #

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'json-schema'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   jbuilder (~> 2.9)
+  json-schema
   json-schema-rspec
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
json-schema is a dependency in `json-schema-rspec` and hence only available in development and test environments.
This PR makes it available in production, and also prevents development/test gems from being loaded in production.