### PR TITLE
Allow missing dates in LAA Reference JSON response

### DIFF
--- a/app/models/laa_reference.rb
+++ b/app/models/laa_reference.rb
@@ -16,8 +16,8 @@ class LaaReference < ApplicationRecord
       laa_reference.statusCode statusCode
       laa_reference.statusDescription statusDescription
       laa_reference.statusDate statusDate.to_date
-      laa_reference.effectiveStartDate effectiveStartDate.to_date
-      laa_reference.effectiveEndDate effectiveEndDate.to_date
+      laa_reference.effectiveStartDate effectiveStartDate&.to_date
+      laa_reference.effectiveEndDate effectiveEndDate&.to_date
     end
   end
 end

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -21,4 +21,24 @@ RSpec.describe LaaReference, type: :model do
   end
 
   it_has_behaviour 'conforming to valid schema'
+
+  describe '#to_builder' do
+    context 'when all the dates are present' do
+      it 'returns a JBuilder object' do
+        expect(subject.to_builder).to be_an_instance_of(Jbuilder)
+      end
+    end
+
+    context 'when there are missing dates' do
+      let(:laa_reference) do
+        FactoryBot.create(:laa_reference,
+                          effectiveStartDate: nil,
+                          effectiveEndDate: nil)
+      end
+
+      it 'returns a JBuilder object' do
+        expect(subject.to_builder).to be_an_instance_of(Jbuilder)
+      end
+    end
+  end
 end


### PR DESCRIPTION
According to the HMCTS schema specification for LAA Reference entity,
effectiveStartDate and effectiveEndDate are optional values.

During testing against this mock api was discovered that the Json
builder was blowing up as the Laa Reference stored in DB does not
contain those date values, but the Json builder assumes its existence
and tries to cast them into a date.

This commit fixes it by returning null for those values when they are
not defined in the database.