### PR TITLE
Refactor array builder to concern

### DIFF
--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -12,7 +12,7 @@ class ProsecutionCasesController < ApplicationController
   def prosecution_cases_response
     return {} if @prosecution_cases.empty?
 
-    { prosecutionCases: Jbuilder.new.array!(prosecution_cases_builder) }
+    { prosecutionCases: prosecution_cases_builder }
   end
 
   def prosecution_cases_builder

--- a/app/models/applicant_counsel.rb
+++ b/app/models/applicant_counsel.rb
@@ -15,8 +15,8 @@ class ApplicantCounsel < ApplicationRecord
       applicant_counsel.middleName middleName
       applicant_counsel.lastName lastName
       applicant_counsel.status status
-      applicant_counsel.applicants Jbuilder.new.array! applicants.ids
-      applicant_counsel.attendanceDays Jbuilder.new.array! attendance_days_builder
+      applicant_counsel.applicants applicants.ids
+      applicant_counsel.attendanceDays attendance_days_builder
     end
   end
 

--- a/app/models/concerns/builder_mappable.rb
+++ b/app/models/concerns/builder_mappable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BuilderMappable
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def array_builder(collection)
+      return nil if collection.empty?
+
+      collection.map { |item| item.to_builder.attributes! }
+    end
+  end
+end

--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CourtApplication < ApplicationRecord
+  include BuilderMappable
   belongs_to :application_type, class_name: 'CourtApplicationType'
   belongs_to :court_application_party
   belongs_to :court_application_outcome, optional: true
@@ -21,7 +22,7 @@ class CourtApplication < ApplicationRecord
       court_application.applicationReceivedDate applicationReceivedDate.to_date
       court_application.applicationReference applicationReference
       court_application.applicant court_application_party.to_builder
-      court_application.respondents court_application_respondents_builder if court_application_respondents.present?
+      court_application.respondents array_builder(court_application_respondents)
       court_application.applicationOutcome court_application_outcome.to_builder if court_application_outcome.present?
       court_application.linkedCaseId linkedCaseId
       court_application.linkedSplitProsecutorCaseReference linkedSplitProsecutorCaseReference
@@ -34,21 +35,7 @@ class CourtApplication < ApplicationRecord
       court_application.breachedOrder breachedOrder
       court_application.breachedOrderDate breachedOrderDate
       court_application.orderingCourt court_centre.to_builder if court_centre.present?
-      court_application.judicialResults judicial_results_builder if judicial_results.present?
-    end
-  end
-
-  private
-
-  def court_application_respondents_builder
-    court_application_respondents.map do |court_application_respondent|
-      court_application_respondent.to_builder.attributes!
-    end
-  end
-
-  def judicial_results_builder
-    judicial_results.map do |judicial_result|
-      judicial_result.to_builder.attributes!
+      court_application.judicialResults array_builder(judicial_results)
     end
   end
 end

--- a/app/models/court_application_party.rb
+++ b/app/models/court_application_party.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CourtApplicationParty < ApplicationRecord
+  include BuilderMappable
   belongs_to :defendant, optional: true
   belongs_to :organisation, optional: true
   belongs_to :person, optional: true
@@ -15,18 +16,10 @@ class CourtApplicationParty < ApplicationRecord
       court_application_party.synonym synonym
       court_application_party.personDetails person.to_builder if person.present?
       court_application_party.organisation organisation.to_builder if organisation.present?
-      court_application_party.organisationPersons Jbuilder.new.array! associated_people_builder if associated_people.present?
+      court_application_party.organisationPersons array_builder(associated_people)
       court_application_party.prosecutingAuthority prosecuting_authority.to_builder if prosecuting_authority.present?
       court_application_party.defendant defendant.to_builder if defendant.present?
       court_application_party.representationOrganisation representation_organisation.to_builder if defendant.present?
-    end
-  end
-
-  private
-
-  def associated_people_builder
-    associated_people.map do |associated_person|
-      associated_person.to_builder.attributes!
     end
   end
 end

--- a/app/models/court_application_party_attendance.rb
+++ b/app/models/court_application_party_attendance.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CourtApplicationPartyAttendance < ApplicationRecord
+  include BuilderMappable
   belongs_to :court_application_party
   has_many :attendance_days
 
@@ -10,15 +11,7 @@ class CourtApplicationPartyAttendance < ApplicationRecord
   def to_builder
     Jbuilder.new do |court_application_party_attendance|
       court_application_party_attendance.courtApplicationPartyId court_application_party_id
-      court_application_party_attendance.attendanceDays attendance_days_builder
-    end
-  end
-
-  private
-
-  def attendance_days_builder
-    attendance_days.map do |attendance_day|
-      attendance_day.to_builder.attributes!
+      court_application_party_attendance.attendanceDays array_builder(attendance_days)
     end
   end
 end

--- a/app/models/court_application_party_counsel.rb
+++ b/app/models/court_application_party_counsel.rb
@@ -16,8 +16,8 @@ class CourtApplicationPartyCounsel < ApplicationRecord
       defence_counsel.middleName middleName
       defence_counsel.lastName lastName
       defence_counsel.status status
-      defence_counsel.applicationRespondents Jbuilder.new.array! court_application_parties.ids if court_application_parties.present?
-      defence_counsel.attendanceDays Jbuilder.new.array! attendance_days_builder
+      defence_counsel.applicationRespondents court_application_parties.ids if court_application_parties.present?
+      defence_counsel.attendanceDays attendance_days_builder
     end
   end
 

--- a/app/models/defence_counsel.rb
+++ b/app/models/defence_counsel.rb
@@ -15,8 +15,8 @@ class DefenceCounsel < ApplicationRecord
       defence_counsel.middleName middleName
       defence_counsel.lastName lastName
       defence_counsel.status status
-      defence_counsel.defendants Jbuilder.new.array! defendants.ids
-      defence_counsel.attendanceDays Jbuilder.new.array! attendance_days_builder
+      defence_counsel.defendants defendants.ids
+      defence_counsel.attendanceDays attendance_days_builder
     end
   end
 

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class Defendant < ApplicationRecord
+  include BuilderMappable
   belongs_to :defendable, polymorphic: true
   belongs_to :prosecution_case, inverse_of: :defendants
   has_many :offences
@@ -61,70 +61,25 @@ class Defendant < ApplicationRecord
       defendant.witnessStatementWelsh witnessStatementWelsh
       defendant.mitigation mitigation
       defendant.mitigationWelsh mitigationWelsh
-      defendant.offences Jbuilder.new.array! offences_builder
-      defendant.associatedPersons Jbuilder.new.array! associated_people_builder if associated_people.present?
-      defendant.associatedDefenceOrganisations Jbuilder.new.array! defence_organisations_builder if defence_organisations.present?
+      defendant.offences array_builder(offences)
+      defendant.associatedPersons array_builder(associated_people)
+      defendant.associatedDefenceOrganisations array_builder(defence_organisations)
       defendant.personDefendant defendable.to_builder if person?
       defendant.legalEntityDefendant defendable.to_builder if legal_entity?
-      defendant.aliases Jbuilder.new.array! defendant_aliases_builder if defendant_aliases.present?
-      defendant.judicialResults Jbuilder.new.array! judicial_results_builder if judicial_results.present?
+      defendant.aliases array_builder(defendant_aliases)
+      defendant.judicialResults array_builder(judicial_results)
       defendant.croNumber croNumber
       defendant.pncId pncId
-      defendant.defendantMarkers Jbuilder.new.array! markers_builder if markers.present?
-      if split_prosecutor_case_references.present?
-        defendant.splitProsecutorCaseReferences Jbuilder.new.array! split_prosecutor_case_references_builder
-      end
+      defendant.defendantMarkers array_builder(markers)
+      defendant.splitProsecutorCaseReferences split_prosecutor_case_references_builder
       defendant.mergedProsecutionCaseReference mergedProsecutionCaseReference
-      defendant.linkedDefendants Jbuilder.new.array! linked_defendants_builder if linked_defendants.present?
+      defendant.linkedDefendants array_builder(linked_defendants)
     end
   end
 
   private
 
-  def offences_builder
-    offences.map do |offence|
-      offence.to_builder.attributes!
-    end
-  end
-
-  def associated_people_builder
-    associated_people.map do |associated_person|
-      associated_person.to_builder.attributes!
-    end
-  end
-
-  def defence_organisations_builder
-    defence_organisations.map do |defence_organisation|
-      defence_organisation.to_builder.attributes!
-    end
-  end
-
-  def defendant_aliases_builder
-    defendant_aliases.map do |defendant_alias|
-      defendant_alias.to_builder.attributes!
-    end
-  end
-
-  def judicial_results_builder
-    judicial_results.map do |judicial_result|
-      judicial_result.to_builder.attributes!
-    end
-  end
-
-  def markers_builder
-    markers.map do |marker|
-      marker.to_builder.attributes!
-    end
-  end
-
   def split_prosecutor_case_references_builder
-    split_prosecutor_case_references.map(&:split)
-  end
-
-  def linked_defendants_builder
-    linked_defendants.map do |linked_defendant|
-      linked_defendant.to_builder.attributes!
-    end
+    split_prosecutor_case_references.map(&:split) if split_prosecutor_case_references.present?
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/defendant_summary.rb
+++ b/app/models/defendant_summary.rb
@@ -20,7 +20,7 @@ class DefendantSummary
       defendant_summary.dateOfBirth defendant.defendable.person.dateOfBirth.to_date if defendant.person?
       defendant_summary.dateOfNextHearing date_of_next_hearing
       defendant_summary.proceedingsConcluded proceedings_concluded?
-      defendant_summary.offences Jbuilder.new.array! offences_builder
+      defendant_summary.offences offences_builder
     end
   end
 

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class Hearing < ApplicationRecord
+  include BuilderMappable
   belongs_to :court_centre
   belongs_to :hearing_type
   belongs_to :cracked_ineffective_trial, optional: true
@@ -25,8 +25,6 @@ class Hearing < ApplicationRecord
   validates :hearing_type, presence: true
   validates :hearing_days, presence: true
   validates :hearingLanguage, inclusion: %w[ENGLISH WELSH]
-
-  # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
   def to_builder
     Jbuilder.new do |hearing|
       hearing.id id
@@ -36,111 +34,23 @@ class Hearing < ApplicationRecord
       hearing.hearingLanguage hearingLanguage
       hearing.hasSharedResults hasSharedResults
       hearing.type hearing_type.to_builder
-      hearing.applicantCounsels applicant_counsels_builder if applicant_counsels.present?
-      hearing.respondentCounsels respondent_counsels_builder if respondent_counsels.present?
-      hearing.prosecutionCounsels prosecution_counsels_builder if prosecution_counsels.present?
-      hearing.defenceCounsels defence_counsels_builder if defence_counsels.present?
-      hearing.applicationPartyCounsels court_application_party_counsels_builder if court_application_party_counsels.present?
+      hearing.applicantCounsels array_builder(applicant_counsels)
+      hearing.respondentCounsels array_builder(respondent_counsels)
+      hearing.prosecutionCounsels array_builder(prosecution_counsels)
+      hearing.defenceCounsels array_builder(defence_counsels)
+      hearing.applicationPartyCounsels array_builder(court_application_party_counsels)
       hearing.crackedIneffectiveTrial cracked_ineffective_trial.to_builder if cracked_ineffective_trial.present?
       hearing.isEffectiveTrial isEffectiveTrial
       hearing.isBoxHearing isBoxHearing
-      hearing.prosecutionCases Jbuilder.new.array! prosecution_cases_builder if prosecution_cases.present?
-      hearing.courtApplications Jbuilder.new.array! court_applications_builder if court_applications.present?
-      hearing.defendantReferralReasons Jbuilder.new.array! referral_reasons_builder if referral_reasons.present?
-      hearing.hearingCaseNotes Jbuilder.new.array! hearing_case_notes_builder if hearing_case_notes.present?
-      hearing.hearingDays Jbuilder.new.array! hearing_days_builder
-      hearing.judiciary Jbuilder.new.array! judicial_roles_builder if judicial_roles.present?
-      hearing.defendantAttendance Jbuilder.new.array! defendant_attendances_builder if defendant_attendances.present?
-      hearing.defendantHearingYouthMarkers Jbuilder.new.array! youth_markers_builder if defendant_hearing_youth_markers.present?
-      hearing.courtApplicationPartyAttendance Jbuilder.new.array! party_attendances_builder if court_application_party_attendances.present?
-    end
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-
-  private
-
-  def prosecution_cases_builder
-    prosecution_cases.map do |prosecution_case|
-      prosecution_case.to_builder.attributes!
-    end
-  end
-
-  def hearing_days_builder
-    hearing_days.map do |hearing_day|
-      hearing_day.to_builder.attributes!
-    end
-  end
-
-  def court_applications_builder
-    court_applications.map do |court_application|
-      court_application.to_builder.attributes!
-    end
-  end
-
-  def defendant_attendances_builder
-    defendant_attendances.map do |defendant_attendance|
-      defendant_attendance.to_builder.attributes!
-    end
-  end
-
-  def referral_reasons_builder
-    referral_reasons.map do |referral_reason|
-      referral_reason.to_builder.attributes!
-    end
-  end
-
-  def hearing_case_notes_builder
-    hearing_case_notes.map do |hearing_case_note|
-      hearing_case_note.to_builder.attributes!
-    end
-  end
-
-  def judicial_roles_builder
-    judicial_roles.map do |judicial_role|
-      judicial_role.to_builder.attributes!
-    end
-  end
-
-  def applicant_counsels_builder
-    applicant_counsels.map do |applicant_counsel|
-      applicant_counsel.to_builder.attributes!
-    end
-  end
-
-  def respondent_counsels_builder
-    respondent_counsels.map do |respondent_counsel|
-      respondent_counsel.to_builder.attributes!
-    end
-  end
-
-  def prosecution_counsels_builder
-    prosecution_counsels.map do |prosecution_counsel|
-      prosecution_counsel.to_builder.attributes!
-    end
-  end
-
-  def defence_counsels_builder
-    defence_counsels.map do |defence_counsel|
-      defence_counsel.to_builder.attributes!
-    end
-  end
-
-  def court_application_party_counsels_builder
-    court_application_party_counsels.map do |court_application_party_counsel|
-      court_application_party_counsel.to_builder.attributes!
-    end
-  end
-
-  def youth_markers_builder
-    defendant_hearing_youth_markers.map do |defendant_hearing_youth_marker|
-      defendant_hearing_youth_marker.to_builder.attributes!
-    end
-  end
-
-  def party_attendances_builder
-    court_application_party_attendances.map do |court_application_party_attendance|
-      court_application_party_attendance.to_builder.attributes!
+      hearing.prosecutionCases array_builder(prosecution_cases)
+      hearing.courtApplications array_builder(court_applications)
+      hearing.defendantReferralReasons array_builder(referral_reasons)
+      hearing.hearingCaseNotes array_builder(hearing_case_notes)
+      hearing.hearingDays array_builder(hearing_days)
+      hearing.judiciary array_builder(judicial_roles)
+      hearing.defendantAttendance array_builder(defendant_attendances)
+      hearing.defendantHearingYouthMarkers array_builder(defendant_hearing_youth_markers)
+      hearing.courtApplicationPartyAttendance array_builder(court_application_party_attendances)
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/hearing_case_note.rb
+++ b/app/models/hearing_case_note.rb
@@ -18,16 +18,10 @@ class HearingCaseNote < ApplicationRecord
       hearing_case_note.originatingHearingId hearing_id
       hearing_case_note.id id
       hearing_case_note.courtClerk court_clerk.to_builder
-      hearing_case_note.prosecutionCases prosecution_cases_builder
+      hearing_case_note.prosecutionCases prosecution_cases.ids
       hearing_case_note.noteDateTime noteDateTime
       hearing_case_note.noteType noteType
       hearing_case_note.note note
     end
-  end
-
-  private
-
-  def prosecution_cases_builder
-    prosecution_cases.ids
   end
 end

--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -17,7 +17,7 @@ class HearingSummary
       hearing_summary.jurisdictionType hearing.jurisdictionType
       hearing_summary.courtCentre hearing.court_centre.to_builder
       hearing_summary.type hearing.hearing_type.to_builder
-      hearing_summary.defendants Jbuilder.new.array! defendants_builder
+      hearing_summary.defendants defendants_builder
     end
   end
 

--- a/app/models/judicial_result.rb
+++ b/app/models/judicial_result.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class JudicialResult < ApplicationRecord
+  include BuilderMappable
   belongs_to :court_clerk, class_name: 'DelegatedPowers', optional: true
   belongs_to :delegated_powers, optional: true
   belongs_to :four_eyes_approval, class_name: 'DelegatedPowers', optional: true
@@ -59,23 +60,11 @@ class JudicialResult < ApplicationRecord
       judicial_result.delegatedPowers delegated_powers.to_builder if delegated_powers.present?
       judicial_result.fourEyesApproval four_eyes_approval.to_builder if four_eyes_approval.present?
       judicial_result.approvedDate approvedDate.to_date
-      judicial_result.usergroups Jbuilder.new.array! user_groups_builder
+      judicial_result.usergroups user_groups.map(&:group)
       judicial_result.category category
       judicial_result.nextHearing next_hearing.to_builder if next_hearing.present?
       judicial_result.durationElement duration_element.to_builder if duration_element.present?
-      judicial_result.judicialResultPrompts Jbuilder.new.array! judicial_result_prompts_builder if judicial_result_prompts.present?
+      judicial_result.judicialResultPrompts array_builder(judicial_result_prompts)
     end
-  end
-
-  private
-
-  def judicial_result_prompts_builder
-    judicial_result_prompts.map do |judicial_result_prompt|
-      judicial_result_prompt.to_builder.attributes!
-    end
-  end
-
-  def user_groups_builder
-    user_groups.map(&:group)
   end
 end

--- a/app/models/judicial_result_prompt.rb
+++ b/app/models/judicial_result_prompt.rb
@@ -19,13 +19,7 @@ class JudicialResultPrompt < ApplicationRecord
       judicial_result_prompt.promptReference promptReference
       judicial_result_prompt.totalPenaltyPoints totalPenaltyPoints
       judicial_result_prompt.isFinancialImposition isFinancialImposition
-      judicial_result_prompt.usergroups Jbuilder.new.array! user_groups_builder
+      judicial_result_prompt.usergroups user_groups.map(&:group)
     end
-  end
-
-  private
-
-  def user_groups_builder
-    user_groups.map(&:group)
   end
 end

--- a/app/models/merged_prosecution_case.rb
+++ b/app/models/merged_prosecution_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class MergedProsecutionCase < ApplicationRecord
+  include BuilderMappable
   has_many :merged_prosecution_case_targets
 
   validates :prosecutionCaseReference, presence: true
@@ -9,15 +10,7 @@ class MergedProsecutionCase < ApplicationRecord
   def to_builder
     Jbuilder.new do |merged_prosecution_case|
       merged_prosecution_case.prosecutionCaseReference prosecutionCaseReference
-      merged_prosecution_case.mergedProsecutionCaseTargets Jbuilder.new.array! merged_prosecution_case_targets_builder
-    end
-  end
-
-  private
-
-  def merged_prosecution_case_targets_builder
-    merged_prosecution_case_targets.map do |merged_prosecution_case_target|
-      merged_prosecution_case_target.to_builder.attributes!
+      merged_prosecution_case.mergedProsecutionCaseTargets array_builder(merged_prosecution_case_targets)
     end
   end
 end

--- a/app/models/next_hearing.rb
+++ b/app/models/next_hearing.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NextHearing < ApplicationRecord
+  include BuilderMappable
   belongs_to :hearing_type
   belongs_to :court_centre
 
@@ -25,27 +26,9 @@ class NextHearing < ApplicationRecord
       next_hearing.reportingRestrictionReason reportingRestrictionReason
       next_hearing.adjournmentReason adjournmentReason
       next_hearing.hearingLanguage hearingLanguage
-      next_hearing.judiciary Jbuilder.new.array! judicial_roles_builder
-      next_hearing.nextHearingProsecutionCases Jbuilder.new.array! next_hearing_prosecution_cases_builder
-      next_hearing.nextHearingCourtApplicationId Jbuilder.new.array! next_hearing_court_applications_builder
+      next_hearing.judiciary array_builder(judicial_roles)
+      next_hearing.nextHearingProsecutionCases array_builder(next_hearing_prosecution_cases)
+      next_hearing.nextHearingCourtApplicationId next_hearing_court_applications.ids
     end
-  end
-
-  private
-
-  def judicial_roles_builder
-    judicial_roles.map do |judicial_role|
-      judicial_role.to_builder.attributes!
-    end
-  end
-
-  def next_hearing_prosecution_cases_builder
-    next_hearing_prosecution_cases.map do |next_hearing_prosecution_case|
-      next_hearing_prosecution_case.to_builder.attributes!
-    end
-  end
-
-  def next_hearing_court_applications_builder
-    next_hearing_court_applications.ids
   end
 end

--- a/app/models/next_hearing_defendant.rb
+++ b/app/models/next_hearing_defendant.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NextHearingDefendant < ApplicationRecord
+  include BuilderMappable
   has_many :next_hearing_offences
   belongs_to :next_hearing_prosecution_case, optional: true, inverse_of: :next_hearing_defendants
 
@@ -9,15 +10,7 @@ class NextHearingDefendant < ApplicationRecord
   def to_builder
     Jbuilder.new do |next_hearing_defendant|
       next_hearing_defendant.id id
-      next_hearing_defendant.offences Jbuilder.new.array! offences_builder
-    end
-  end
-
-  private
-
-  def offences_builder
-    next_hearing_offences.map do |next_hearing_offence|
-      next_hearing_offence.to_builder.attributes!
+      next_hearing_defendant.offences array_builder(next_hearing_offences)
     end
   end
 end

--- a/app/models/next_hearing_prosecution_case.rb
+++ b/app/models/next_hearing_prosecution_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NextHearingProsecutionCase < ApplicationRecord
+  include BuilderMappable
   has_many :next_hearing_defendants
 
   belongs_to :next_hearing, optional: true, inverse_of: :next_hearing_prosecution_cases
@@ -10,15 +11,7 @@ class NextHearingProsecutionCase < ApplicationRecord
   def to_builder
     Jbuilder.new do |next_hearing_prosecution_case|
       next_hearing_prosecution_case.id id
-      next_hearing_prosecution_case.defendants Jbuilder.new.array! defendants_builder
-    end
-  end
-
-  private
-
-  def defendants_builder
-    next_hearing_defendants.map do |next_hearing_offence|
-      next_hearing_offence.to_builder.attributes!
+      next_hearing_prosecution_case.defendants array_builder(next_hearing_defendants)
     end
   end
 end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Offence < ApplicationRecord
+  include BuilderMappable
   belongs_to :notified_plea, optional: true
   belongs_to :indicated_plea, optional: true
   belongs_to :allocation_decision, optional: true
@@ -47,35 +48,15 @@ class Offence < ApplicationRecord
       offence.verdict verdict.to_builder if verdict.present?
       offence.offenceFacts offence_facts.to_builder if offence_facts.present?
       offence.aquittalDate aquittalDate.to_date
-      offence.victims Jbuilder.new.array! victims_builder if victims.present?
-      offence.judicialResults Jbuilder.new.array! judicial_results_builder if judicial_results.present?
+      offence.victims array_builder(victims)
+      offence.judicialResults array_builder(judicial_results)
       offence.isDisposed isDisposed
       offence.isDiscontinued isDiscontinued
       offence.isIntroduceAfterInitialProceedings isIntroduceAfterInitialProceedings
-      offence.laaApplnReferences Jbuilder.new.array! laa_references_builder if laa_references.present?
+      offence.laaApplnReferences array_builder(laa_references)
       offence.custodyTimeLimit custody_time_limit.to_builder if custody_time_limit.present?
       offence.splitProsecutorCaseReference splitProsecutorCaseReference
       offence.mergedProsecutionCaseReference mergedProsecutionCaseReference
-    end
-  end
-
-  private
-
-  def victims_builder
-    victims.map do |victim|
-      victim.to_builder.attributes!
-    end
-  end
-
-  def judicial_results_builder
-    judicial_results.map do |judicial_result|
-      judicial_result.to_builder.attributes!
-    end
-  end
-
-  def laa_references_builder
-    laa_references.map do |laa_reference|
-      laa_reference.to_builder.attributes!
     end
   end
 end

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ProsecutionCase < ApplicationRecord
+  include BuilderMappable
   INITIATION_CODES = %w[J Q S C R O Z].freeze
   CASE_STATUSES = %w[ACTIVE INACTIVE].freeze
 
@@ -36,35 +37,13 @@ class ProsecutionCase < ApplicationRecord
       prosecution_case.statementOfFactsWelsh statementOfFactsWelsh
       prosecution_case.breachProceedingsPending breachProceedingsPending
       prosecution_case.appealProceedingsPending appealProceedingsPending
-      prosecution_case.defendants Jbuilder.new.array! defendants_builder
-      prosecution_case.caseMarkers Jbuilder.new.array! markers_builder if markers.present?
+      prosecution_case.defendants array_builder(defendants)
+      prosecution_case.caseMarkers array_builder(markers)
       if split_prosecutor_case_references.present?
-        prosecution_case.splitProsecutorCaseReferences Jbuilder.new.array! split_prosecutor_case_references_builder
+        prosecution_case.splitProsecutorCaseReferences split_prosecutor_case_references.map(&:split)
       end
       prosecution_case.mergedProsecutionCase merged_prosecution_case.to_builder if merged_prosecution_case.present?
-      prosecution_case.linkedProsecutionCases Jbuilder.new.array! linked_prosecution_cases_builder if linked_prosecution_cases.present?
+      prosecution_case.linkedProsecutionCases linked_prosecution_cases.ids if linked_prosecution_cases.present?
     end
-  end
-
-  private
-
-  def defendants_builder
-    defendants.map do |defendant|
-      defendant.to_builder.attributes!
-    end
-  end
-
-  def markers_builder
-    markers.map do |marker|
-      marker.to_builder.attributes!
-    end
-  end
-
-  def split_prosecutor_case_references_builder
-    split_prosecutor_case_references.map(&:split)
-  end
-
-  def linked_prosecution_cases_builder
-    linked_prosecution_cases.ids
   end
 end

--- a/app/models/prosecution_case_summary.rb
+++ b/app/models/prosecution_case_summary.rb
@@ -16,8 +16,8 @@ class ProsecutionCaseSummary
       prosecution_case_summary.prosecutionCaseId prosecution_case_id
       prosecution_case_summary.prosecutionCaseReference prosecution_case_reference
       prosecution_case_summary.caseStatus prosecution_case.caseStatus
-      prosecution_case_summary.defendants Jbuilder.new.array! defendants_builder
-      prosecution_case_summary.hearings Jbuilder.new.array! hearings_builder if prosecution_case.hearing_id.present?
+      prosecution_case_summary.defendants defendants_builder
+      prosecution_case_summary.hearings hearings_builder if prosecution_case.hearing_id.present?
     end
   end
 

--- a/app/models/prosecution_counsel.rb
+++ b/app/models/prosecution_counsel.rb
@@ -15,8 +15,8 @@ class ProsecutionCounsel < ApplicationRecord
       applicant_counsel.middleName middleName
       applicant_counsel.lastName lastName
       applicant_counsel.status status
-      applicant_counsel.prosecutionCases Jbuilder.new.array! prosecution_cases.ids
-      applicant_counsel.attendanceDays Jbuilder.new.array! attendance_days_builder
+      applicant_counsel.prosecutionCases prosecution_cases.ids
+      applicant_counsel.attendanceDays attendance_days_builder
     end
   end
 

--- a/app/models/respondent_counsel.rb
+++ b/app/models/respondent_counsel.rb
@@ -15,8 +15,8 @@ class RespondentCounsel < ApplicationRecord
       respondent_counsel.middleName middleName
       respondent_counsel.lastName lastName
       respondent_counsel.status status
-      respondent_counsel.respondents Jbuilder.new.array! court_application_respondents.ids
-      respondent_counsel.attendanceDays Jbuilder.new.array! attendance_days_builder
+      respondent_counsel.respondents court_application_respondents.ids
+      respondent_counsel.attendanceDays attendance_days_builder
     end
   end
 


### PR DESCRIPTION
Refactored to move common array builder attributes to a concern.
Also, since we have have [defaulted to ignoring `nil` attributes](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/blob/master/config/initializers/jbuilder.rb#L3) we no longer need many of the original conditional checks.
