### PR TITLE
Add simplecov gem to monitor test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 /config/master.key
 
 spec/examples.txt
+
+# Ignore simplecov coverage stats
+/coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ end
 group :test do
   gem 'rspec_junit_formatter'
   gem 'shoulda-matchers'
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -91,6 +92,7 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    json (2.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     json-schema-rspec (0.0.4)
@@ -201,6 +203,11 @@ GEM
     safe_yaml (1.0.5)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -253,6 +260,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   shoulda-matchers
+  simplecov
   sinatra
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/spec/models/prosecution_case_summary_spec.rb
+++ b/spec/models/prosecution_case_summary_spec.rb
@@ -11,4 +11,13 @@ RSpec.describe ProsecutionCaseSummary, type: :model do
   subject { prosecution_case_summary }
 
   it_has_behaviour 'conforming to valid schema'
+
+  context 'with a hearing relationship' do
+    before do
+      prosecution_case.hearing = FactoryBot.create(:hearing)
+      prosecution_case.save!
+    end
+
+    it_has_behaviour 'conforming to valid schema'
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,16 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
+require 'simplecov'
 require 'webmock/rspec'
 require_relative './support/fake_common_platform'
+
+SimpleCov.minimum_coverage 100
+unless ENV['NOCOVERAGE']
+  SimpleCov.start do
+    add_filter 'spec/'
+  end
+end
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
## What

This PR:

* Adds `simplecov` to the gemfile
* Configures `simplecov` to mandate 100% code coverage and not include specs in the coverage calculation
* Updates `.gitignore` to prevent code coverage details being committed
* Adds an extra test to `prosecution_case_summary_spec` to ensure 100% coverage

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
