### PR TITLE
Move 'require rails_helper' to .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--require rails_helper

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ApplicationController, type: :controller do
   describe 'handling InvalidParams' do
     controller do

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingsController, type: :controller do
   let(:hearing) { FactoryBot.create(:hearing) }
   describe 'GET #show' do

--- a/spec/controllers/laa_references_controller_spec.rb
+++ b/spec/controllers/laa_references_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe LaaReferencesController, type: :controller do
   let(:defendant) { FactoryBot.create(:defendant) }

--- a/spec/controllers/prosecution_cases_controller_spec.rb
+++ b/spec/controllers/prosecution_cases_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCasesController, type: :controller do
   describe 'GET #index' do
     it 'returns unauthorized' do

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe StatusController, type: :controller do
   describe 'GET #index' do
     it 'returns http success' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Address, type: :model do
   let(:address) { FactoryBot.create(:address) }
 

--- a/spec/models/allocation_decision_spec.rb
+++ b/spec/models/allocation_decision_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe AllocationDecision, type: :model do
   let(:allocation_decision) { FactoryBot.create(:allocation_decision) }
   let(:json_schema) { :allocation_decision }

--- a/spec/models/applicant_counsel_spec.rb
+++ b/spec/models/applicant_counsel_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ApplicantCounsel, type: :model do
   let(:applicant_counsel) { FactoryBot.create(:applicant_counsel) }
   let(:json_schema) { :applicant_counsel }

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Applicant, type: :model do
   let(:applicant) { FactoryBot.create(:applicant) }
 

--- a/spec/models/associated_person_spec.rb
+++ b/spec/models/associated_person_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe AssociatedPerson, type: :model do
   let(:associated_person) { FactoryBot.create(:associated_person) }
 

--- a/spec/models/attendance_day_spec.rb
+++ b/spec/models/attendance_day_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe AttendanceDay, type: :model do
   let(:attendance_day) { FactoryBot.create(:attendance_day) }
   let(:json_schema) { :attendance_day }

--- a/spec/models/bail_status_spec.rb
+++ b/spec/models/bail_status_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe BailStatus, type: :model do
   let(:bail_status) { FactoryBot.create(:bail_status) }
 

--- a/spec/models/contact_number_spec.rb
+++ b/spec/models/contact_number_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ContactNumber, type: :model do
   let(:contact_number) { FactoryBot.create(:contact_number) }
 

--- a/spec/models/court_application_outcome_spec.rb
+++ b/spec/models/court_application_outcome_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationOutcome, type: :model do
   let(:court_application_outcome) { FactoryBot.create(:court_application_outcome) }
 

--- a/spec/models/court_application_outcome_type_spec.rb
+++ b/spec/models/court_application_outcome_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationOutcomeType, type: :model do
   let(:court_application_outcome_type) { FactoryBot.create(:court_application_outcome_type) }
 

--- a/spec/models/court_application_party_attendance_spec.rb
+++ b/spec/models/court_application_party_attendance_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationPartyAttendance, type: :model do
   let(:court_application_party_attendance) { FactoryBot.create(:court_application_party_attendance) }
 

--- a/spec/models/court_application_party_counsel_spec.rb
+++ b/spec/models/court_application_party_counsel_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationPartyCounsel, type: :model do
   let(:court_application_party_counsel) { FactoryBot.create(:court_application_party_counsel) }
   let(:json_schema) { :court_application_party_counsel }

--- a/spec/models/court_application_party_spec.rb
+++ b/spec/models/court_application_party_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationParty, type: :model do
   let(:court_application_party) { FactoryBot.create(:court_application_party) }
 

--- a/spec/models/court_application_payment_spec.rb
+++ b/spec/models/court_application_payment_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationPayment, type: :model do
   let(:court_application_payment) { FactoryBot.create(:court_application_payment) }
 

--- a/spec/models/court_application_respondent_spec.rb
+++ b/spec/models/court_application_respondent_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationRespondent, type: :model do
   let(:court_application_respondent) { FactoryBot.create(:court_application_respondent) }
 

--- a/spec/models/court_application_response_spec.rb
+++ b/spec/models/court_application_response_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationResponse, type: :model do
   let(:court_application_response) { FactoryBot.create(:court_application_response) }
 

--- a/spec/models/court_application_response_type_spec.rb
+++ b/spec/models/court_application_response_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationResponseType, type: :model do
   let(:court_application_response_type) { FactoryBot.create(:court_application_response_type) }
 

--- a/spec/models/court_application_spec.rb
+++ b/spec/models/court_application_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplication, type: :model do
   let(:court_application) { FactoryBot.create(:court_application) }
   let(:json_schema) { :court_application }

--- a/spec/models/court_application_type_spec.rb
+++ b/spec/models/court_application_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtApplicationType, type: :model do
   let(:court_application_type) { FactoryBot.create(:court_application_type) }
   let(:json_schema) { :court_application_type }

--- a/spec/models/court_centre_spec.rb
+++ b/spec/models/court_centre_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtCentre, type: :model do
   let(:court_centre) { FactoryBot.create(:court_centre) }
 

--- a/spec/models/court_indicated_sentence_spec.rb
+++ b/spec/models/court_indicated_sentence_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CourtIndicatedSentence, type: :model do
   let(:court_indicated_sentence) { FactoryBot.create(:court_indicated_sentence) }
 

--- a/spec/models/cracked_ineffective_trial_spec.rb
+++ b/spec/models/cracked_ineffective_trial_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CrackedIneffectiveTrial, type: :model do
   let(:cracked_ineffective_trial) { FactoryBot.create(:cracked_ineffective_trial) }
   let(:json_schema) { :cracked_ineffective_trial }

--- a/spec/models/custody_time_limit_spec.rb
+++ b/spec/models/custody_time_limit_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe CustodyTimeLimit, type: :model do
   let(:custody_time_limit) { FactoryBot.create(:custody_time_limit) }
 

--- a/spec/models/defence_counsel_spec.rb
+++ b/spec/models/defence_counsel_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefenceCounsel, type: :model do
   let(:defence_counsel) { FactoryBot.create(:defence_counsel) }
   let(:json_schema) { :defence_counsel }

--- a/spec/models/defence_organisation_spec.rb
+++ b/spec/models/defence_organisation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefenceOrganisation, type: :model do
   let(:defence_organisation) { FactoryBot.create(:defence_organisation) }
   let(:json_schema) { :defence_organisation }

--- a/spec/models/defendant_alias_spec.rb
+++ b/spec/models/defendant_alias_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefendantAlias, type: :model do
   let(:defendant_alias) { FactoryBot.create(:defendant_alias) }
 

--- a/spec/models/defendant_attendance_spec.rb
+++ b/spec/models/defendant_attendance_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefendantAttendance, type: :model do
   let(:defendant_attendance) { FactoryBot.create(:defendant_attendance) }
   let(:json_schema) { :defendant_attendance }

--- a/spec/models/defendant_hearing_youth_marker_spec.rb
+++ b/spec/models/defendant_hearing_youth_marker_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefendantHearingYouthMarker, type: :model do
   let(:defendant_hearing_youth_marker) { FactoryBot.create(:defendant_hearing_youth_marker) }
   let(:json_schema) { :defendant_hearing_youth_marker }

--- a/spec/models/defendant_name_spec.rb
+++ b/spec/models/defendant_name_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefendantName, type: :model do
   let(:defendant) { FactoryBot.create(:defendant) }
   let(:defendant_name) { described_class.new(defendant_id: defendant.id) }

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Defendant, type: :model do
   let(:defendant) { FactoryBot.create(:defendant) }

--- a/spec/models/defendant_summary_spec.rb
+++ b/spec/models/defendant_summary_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DefendantSummary, type: :model do
   let(:defendant) { FactoryBot.create(:defendant) }
   let(:defendant_summary) { described_class.new(defendant_id: defendant.id) }

--- a/spec/models/delegated_powers_spec.rb
+++ b/spec/models/delegated_powers_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe DelegatedPowers, type: :model do
   let(:delegated_powers) { FactoryBot.create(:delegated_powers) }
 

--- a/spec/models/ethnicity_spec.rb
+++ b/spec/models/ethnicity_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Ethnicity, type: :model do
   let(:ethnicity) { FactoryBot.create(:ethnicity) }
 

--- a/spec/models/hearing_case_note_spec.rb
+++ b/spec/models/hearing_case_note_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingCaseNote, type: :model do
   let(:hearing_case_note) { FactoryBot.create(:hearing_case_note) }
   let(:json_schema) { :hearing_case_note }

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingDay, type: :model do
   let(:hearing_day) { FactoryBot.create(:hearing_day) }
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Hearing, type: :model do
   let(:hearing) { FactoryBot.create(:hearing) }

--- a/spec/models/hearing_summary_spec.rb
+++ b/spec/models/hearing_summary_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingSummary, type: :model do
   let(:hearing) { FactoryBot.create(:hearing) }
   let(:hearing_summary) { described_class.new(hearing_id: hearing.id) }

--- a/spec/models/hearing_type_spec.rb
+++ b/spec/models/hearing_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingType, type: :model do
   let(:hearing_type) { FactoryBot.create(:hearing_type) }
 

--- a/spec/models/indicated_plea_spec.rb
+++ b/spec/models/indicated_plea_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe IndicatedPlea, type: :model do
   let(:indicated_plea) { FactoryBot.create(:indicated_plea) }
 

--- a/spec/models/judicial_result_prompt_duration_element_spec.rb
+++ b/spec/models/judicial_result_prompt_duration_element_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe JudicialResultPromptDurationElement, type: :model do
   let(:judicial_result_prompt_duration_element) { FactoryBot.create(:judicial_result_prompt_duration_element) }
 

--- a/spec/models/judicial_result_prompt_spec.rb
+++ b/spec/models/judicial_result_prompt_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe JudicialResultPrompt, type: :model do
   let(:judicial_result_prompt) { FactoryBot.create(:judicial_result_prompt) }
 

--- a/spec/models/judicial_result_spec.rb
+++ b/spec/models/judicial_result_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-require 'rails_helper'
 RSpec.describe JudicialResult, type: :model do
   let(:judicial_result) { FactoryBot.create(:judicial_result) }
   let(:json_schema) { :judicial_result }

--- a/spec/models/judicial_role_spec.rb
+++ b/spec/models/judicial_role_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe JudicialRole, type: :model do
   let(:judicial_role) { FactoryBot.create(:judicial_role) }
 

--- a/spec/models/judicial_role_type_spec.rb
+++ b/spec/models/judicial_role_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe JudicialRoleType, type: :model do
   let(:judicial_role_type) { FactoryBot.create(:judicial_role_type) }
   let(:json_schema) { :judicial_role_type }

--- a/spec/models/jurors_spec.rb
+++ b/spec/models/jurors_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Jurors, type: :model do
   let(:jurors) { FactoryBot.create(:jurors) }
 

--- a/spec/models/laa_reference_spec.rb
+++ b/spec/models/laa_reference_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LaaReference, type: :model do
   let(:laa_reference) { FactoryBot.create(:laa_reference) }
 

--- a/spec/models/legal_entity_defendant_spec.rb
+++ b/spec/models/legal_entity_defendant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LegalEntityDefendant, type: :model do
   let(:legal_entity_defendant) { FactoryBot.create(:legal_entity_defendant) }
 

--- a/spec/models/lesser_or_alternative_offence_spec.rb
+++ b/spec/models/lesser_or_alternative_offence_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LesserOrAlternativeOffence, type: :model do
   let(:lesser_or_alternative_offence) { FactoryBot.create(:lesser_or_alternative_offence) }
 

--- a/spec/models/linked_defendant_spec.rb
+++ b/spec/models/linked_defendant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LinkedDefendant, type: :model do
   let(:linked_defendant) { FactoryBot.create(:linked_defendant) }
 

--- a/spec/models/linked_prosecution_case_spec.rb
+++ b/spec/models/linked_prosecution_case_spec.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LinkedProsecutionCase, type: :model do
 end

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Marker, type: :model do
   let(:marker) { FactoryBot.create(:marker) }
 

--- a/spec/models/merged_prosecution_case_spec.rb
+++ b/spec/models/merged_prosecution_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe MergedProsecutionCase, type: :model do
   let(:merged_prosecution_case) { FactoryBot.create(:merged_prosecution_case) }
 

--- a/spec/models/merged_prosecution_case_target_spec.rb
+++ b/spec/models/merged_prosecution_case_target_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe MergedProsecutionCaseTarget, type: :model do
   let(:merged_prosecution_case_target) { FactoryBot.create(:merged_prosecution_case_target) }
 

--- a/spec/models/next_hearing_court_application_spec.rb
+++ b/spec/models/next_hearing_court_application_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NextHearingCourtApplication, type: :model do
   describe 'associations' do
     it { should belong_to(:next_hearing).class_name('NextHearing').optional }

--- a/spec/models/next_hearing_defendant_spec.rb
+++ b/spec/models/next_hearing_defendant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NextHearingDefendant, type: :model do
   let(:next_hearing_defendant) { FactoryBot.create(:next_hearing_defendant) }
 

--- a/spec/models/next_hearing_offence_spec.rb
+++ b/spec/models/next_hearing_offence_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NextHearingOffence, type: :model do
   let(:next_hearing_offence) { FactoryBot.create(:next_hearing_offence) }
 

--- a/spec/models/next_hearing_prosecution_case_spec.rb
+++ b/spec/models/next_hearing_prosecution_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NextHearingProsecutionCase, type: :model do
   let(:next_hearing_prosecution_case) { FactoryBot.create(:next_hearing_prosecution_case) }
 

--- a/spec/models/next_hearing_spec.rb
+++ b/spec/models/next_hearing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NextHearing, type: :model do
   let(:next_hearing) { FactoryBot.create(:next_hearing) }
 

--- a/spec/models/notified_plea_spec.rb
+++ b/spec/models/notified_plea_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe NotifiedPlea, type: :model do
   let(:notified_plea) { FactoryBot.create(:notified_plea) }
 

--- a/spec/models/offence_facts_spec.rb
+++ b/spec/models/offence_facts_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe OffenceFacts, type: :model do
   let(:offence_facts) { FactoryBot.create(:offence_facts) }
   let(:json_schema) { :offence_facts }

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Offence, type: :model do
   let(:offence) { FactoryBot.create(:offence) }

--- a/spec/models/offence_summary_spec.rb
+++ b/spec/models/offence_summary_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe OffenceSummary, type: :model do
   let(:offence) { FactoryBot.create(:offence) }
   let(:offence_summary) { described_class.new(offence_id: offence.id) }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Organisation, type: :model do
   let(:organisation) { FactoryBot.create(:organisation) }
   let(:json_schema) { :organisation }

--- a/spec/models/person_defendant_spec.rb
+++ b/spec/models/person_defendant_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe PersonDefendant, type: :model do
   let(:person_defendant) { FactoryBot.create(:person_defendant) }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Person, type: :model do
   let(:person) { FactoryBot.create(:person) }

--- a/spec/models/plea_spec.rb
+++ b/spec/models/plea_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Plea, type: :model do
   let(:plea) { FactoryBot.create(:plea) }
   let(:json_schema) { :plea }

--- a/spec/models/police_officer_in_case_spec.rb
+++ b/spec/models/police_officer_in_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe PoliceOfficerInCase, type: :model do
   let(:police_officer_in_case) { FactoryBot.create(:police_officer_in_case) }
   let(:json_schema) { :police_officer_in_case }

--- a/spec/models/prosecuting_authority_spec.rb
+++ b/spec/models/prosecuting_authority_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutingAuthority, type: :model do
   let(:prosecuting_authority) { FactoryBot.create(:prosecuting_authority) }
 

--- a/spec/models/prosecution_case_hearing_case_note_spec.rb
+++ b/spec/models/prosecution_case_hearing_case_note_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCaseHearingCaseNote, type: :model do
   describe 'associations' do
     it { should belong_to(:hearing_case_note).class_name('HearingCaseNote') }

--- a/spec/models/prosecution_case_identifier_spec.rb
+++ b/spec/models/prosecution_case_identifier_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCaseIdentifier, type: :model do
   let(:prosecution_case_identifier) { FactoryBot.create(:prosecution_case_identifier) }
   let(:json_schema) { :prosecution_case_identifier }

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe ProsecutionCase, type: :model do
   let(:prosecution_case) { FactoryBot.create(:prosecution_case) }

--- a/spec/models/prosecution_case_summary_spec.rb
+++ b/spec/models/prosecution_case_summary_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCaseSummary, type: :model do
   let(:prosecution_case) { FactoryBot.create(:prosecution_case) }
   let(:prosecution_case_summary) { described_class.new(prosecution_case_id: prosecution_case.id) }

--- a/spec/models/prosecution_counsel_spec.rb
+++ b/spec/models/prosecution_counsel_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ProsecutionCounsel, type: :model do
   let(:prosecution_counsel) { FactoryBot.create(:prosecution_counsel) }
   let(:json_schema) { :prosecution_counsel }

--- a/spec/models/referral_reason_spec.rb
+++ b/spec/models/referral_reason_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ReferralReason, type: :model do
   let(:referral_reason) { FactoryBot.create(:referral_reason) }
   let(:json_schema) { :referral_reason }

--- a/spec/models/respondent_counsel_spec.rb
+++ b/spec/models/respondent_counsel_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe RespondentCounsel, type: :model do
   let(:respondent_counsel) { FactoryBot.create(:respondent_counsel) }
   let(:json_schema) { :respondent_counsel }

--- a/spec/models/split_prosecutor_case_reference_spec.rb
+++ b/spec/models/split_prosecutor_case_reference_spec.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe SplitProsecutorCaseReference, type: :model do
 end

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe UserGroup, type: :model do
   describe 'associations' do
     it { should belong_to(:judicial_result_prompt).class_name('JudicialResultPrompt').optional }

--- a/spec/models/verdict_spec.rb
+++ b/spec/models/verdict_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Verdict, type: :model do
   let(:verdict) { FactoryBot.create(:verdict) }
   let(:json_schema) { :verdict }

--- a/spec/models/verdict_type_spec.rb
+++ b/spec/models/verdict_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe VerdictType, type: :model do
   let(:verdict_type) { FactoryBot.create(:verdict_type) }
   let(:json_schema) { :verdict_type }

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'Hearings', type: :request do
   describe 'GET /hearing/result-sit/LAAGetHearingHttpTrigger' do
     let(:hearing) { FactoryBot.create(:hearing) }

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'ProsecutionCases', type: :request do
   let(:headers) { { 'LAASearchCase-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE') } }
 

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe ApplicationService do
   subject { described_class.call('some', 'arguments') }
 

--- a/spec/services/hearing_finder_spec.rb
+++ b/spec/services/hearing_finder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingFinder do
   let(:params) { ActionController::Parameters.new(params_hash) }
 

--- a/spec/services/hearing_resulted_publisher_spec.rb
+++ b/spec/services/hearing_resulted_publisher_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe HearingResultedPublisher do
   let(:hearing) { FactoryBot.create(:hearing) }
   let(:shared_time) { '2019-12-12T00:00:00+00:00' }

--- a/spec/services/laa_connector_spec.rb
+++ b/spec/services/laa_connector_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe LaaConnector do
   let(:laa_adaptor_url) { 'https://example.org' }
   let(:auth_token) { 'AUTH TOKEN' }

--- a/spec/services/laa_reference_recorder_spec.rb
+++ b/spec/services/laa_reference_recorder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe LaaReferenceRecorder do
   let(:params) { ActionController::Parameters.new(params_hash) }

--- a/spec/services/laa_representation_order_recorder_spec.rb
+++ b/spec/services/laa_representation_order_recorder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 # rubocop:disable Metrics/BlockLength
 RSpec.describe LaaRepresentationOrderRecorder do
   let(:params) { ActionController::Parameters.new(params_hash) }

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
 # rubocop:disable Metrics/BlockLength
 RSpec.describe ProsecutionCaseSearch do
   let(:params) { ActionController::Parameters.new(params_hash) }

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.shared_examples 'conforming to valid schema' do
   it 'matches the given schema' do
     expect(subject.to_builder.target!).to match_json_schema(json_schema)

--- a/spec/support/unauthorised_request.rb
+++ b/spec/support/unauthorised_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.shared_examples 'an unauthorised request' do
   it 'responds with a 401 status code' do
     get :index

--- a/spec/tasks/publish_spec.rb
+++ b/spec/tasks/publish_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'Publish Task', type: :rake do
   include ActiveSupport::Testing::TimeHelpers
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-CACP-165)

This PR adds `--require rails_helper` to the `.rspec` file and removes it from each individual spec.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
