### PR TITLE
Remove '-sit' from urls

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -11,7 +11,7 @@ class HearingsController < ApplicationController
 
   def authenticate
     authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('LAHearing-Subscription-Key', ''),
+      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
       ENV.fetch('SHARED_SECRET_KEY_HEARING')
     )
 

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -23,7 +23,7 @@ class LaaReferencesController < ApplicationController
 
   def authenticate_record_reference
     authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('LAAReference-Subscription-Key', ''),
+      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
       ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
     )
 
@@ -32,7 +32,7 @@ class LaaReferencesController < ApplicationController
 
   def authenticate_record_representation_order
     authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('LAARepresent-Subscription-Key', ''),
+      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
       ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
     )
 

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -23,7 +23,7 @@ class ProsecutionCasesController < ApplicationController
 
   def authenticate
     authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('LAASearchCase-Subscription-Key', ''),
+      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
       ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE')
     )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,17 +3,17 @@
 Rails.application.routes.draw do
   resources :status, only: [:index]
 
-  resources :prosecution_cases, path: '/search/case-sit/prosecutionCases', only: [:index]
+  resources :prosecution_cases, path: '/search/case/prosecutionCases', only: [:index]
 
-  post '/record/laareference-sit/progression-command-api'\
+  post '/record/laareference/progression-command-api'\
     '/command/api/rest/progression/laaReference'\
     '/cases/:prosecutionCaseId'\
     '/defendants/:defendantId'\
     '/offences/:offenceId' => 'laa_references#record_reference', as: :laa_reference
-  post '/receive/representation-sit/progression-command-api'\
+  post '/receive/representation/progression-command-api'\
     '/command/api/rest/progression/representationOrder' \
     '/cases/:prosecutionCaseId' \
     '/defendants/:defendantId' \
     '/offences/:offenceId' => 'laa_references#record_representation_order', as: :representation_order
-  get '/hearing/result-sit/LAAGetHearingHttpTrigger' => 'hearings#show', as: :hearing
+  get '/hearing/result/LAAGetHearingHttpTrigger' => 'hearings#show', as: :hearing
 end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HearingsController, type: :controller do
 
     context 'with the correct auth header' do
       it 'returns a success response' do
-        request.headers['LAHearing-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_HEARING')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_HEARING')
         get :show, params: { hearingId: hearing.id }
         expect(response).to be_successful
       end

--- a/spec/controllers/laa_references_controller_spec.rb
+++ b/spec/controllers/laa_references_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe LaaReferencesController, type: :controller do
       before { laa_reference.save! }
 
       it 'returns a no_content status' do
-        request.headers['LAAReference-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
         put :record_reference, params: laa_reference_params
         expect(response).to have_http_status(:no_content)
       end
@@ -46,7 +46,7 @@ RSpec.describe LaaReferencesController, type: :controller do
 
     context 'when the LaaReference is new' do
       it 'returns a created status' do
-        request.headers['LAAReference-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
         put :record_reference, params: laa_reference_params
         expect(response).to have_http_status(:created)
       end
@@ -81,7 +81,7 @@ RSpec.describe LaaReferencesController, type: :controller do
       before { laa_reference.save! }
 
       it 'returns a no_content status' do
-        request.headers['LAARepresent-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
         put :record_representation_order, params: laa_reference_params
         expect(response).to have_http_status(:no_content)
       end
@@ -89,7 +89,7 @@ RSpec.describe LaaReferencesController, type: :controller do
 
     context 'when the LaaReference is new' do
       it 'returns a created status' do
-        request.headers['LAARepresent-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
         put :record_representation_order, params: laa_reference_params
         expect(response).to have_http_status(:created)
       end

--- a/spec/controllers/prosecution_cases_controller_spec.rb
+++ b/spec/controllers/prosecution_cases_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProsecutionCasesController, type: :controller do
 
     context 'with the correct auth header' do
       it 'returns a success response' do
-        request.headers['LAASearchCase-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE')
         get :index, params: { prosecutionCaseReference: 'some reference' }
         expect(response).to be_successful
       end

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Hearings', type: :request do
-  describe 'GET /hearing/result-sit/LAAGetHearingHttpTrigger' do
+  describe 'GET /hearing/result/LAAGetHearingHttpTrigger' do
     let(:hearing) { FactoryBot.create(:hearing) }
     let(:headers) { { 'LAHearing-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_HEARING') } }
 
     it 'matches the response schema' do
-      get "/hearing/result-sit/LAAGetHearingHttpTrigger?hearingId=#{hearing.id}", headers: headers
+      get "/hearing/result/LAAGetHearingHttpTrigger?hearingId=#{hearing.id}", headers: headers
       expect(response).to have_http_status(200)
       expect(response.body).to match_json_schema(:results_hearing_resulted_response)
     end

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Hearings', type: :request do
   describe 'GET /hearing/result/LAAGetHearingHttpTrigger' do
     let(:hearing) { FactoryBot.create(:hearing) }
-    let(:headers) { { 'LAHearing-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_HEARING') } }
+    let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_HEARING') } }
 
     it 'matches the response schema' do
       get "/hearing/result/LAAGetHearingHttpTrigger?hearingId=#{hearing.id}", headers: headers

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'ProsecutionCases', type: :request do
-  let(:headers) { { 'LAASearchCase-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE') } }
+  let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE') } }
 
   describe 'GET /search/case/prosecutionCases' do
     let!(:prosecution_case) do

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'ProsecutionCases', type: :request do
   let(:headers) { { 'LAASearchCase-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE') } }
 
-  describe 'GET /search/case-sit/prosecutionCases' do
+  describe 'GET /search/case/prosecutionCases' do
     let!(:prosecution_case) do
       FactoryBot.create(:prosecution_case,
                         prosecution_case_identifier: FactoryBot.create(:prosecution_case_identifier,
@@ -11,7 +11,7 @@ RSpec.describe 'ProsecutionCases', type: :request do
     end
 
     it 'matches the response schema' do
-      get '/search/case-sit/prosecutionCases?prosecutionCaseReference=some-reference', headers: headers
+      get '/search/case/prosecutionCases?prosecutionCaseReference=some-reference', headers: headers
       expect(response).to have_http_status(200)
       # For some odd reason the HMCTS results do not contain the prosecutionCases key as defined by the schema
       # but only the array items instead
@@ -20,7 +20,7 @@ RSpec.describe 'ProsecutionCases', type: :request do
 
     context 'when the search returns no results' do
       it 'matches the response schema' do
-        get '/search/case-sit/prosecutionCases?prosecutionCaseReference=incorrect-reference', headers: headers
+        get '/search/case/prosecutionCases?prosecutionCaseReference=incorrect-reference', headers: headers
         expect(response).to have_http_status(200)
         expect(response.body).to match_json_schema(:search_prosecution_case_response)
       end


### PR DESCRIPTION
## What

Several API paths include the string `-sit`. HMCTS have informed us that their APIs do not include this, so we should remove it from the mock.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
