### PR TITLE
Add prosecution_case trait to hearings factory

### DIFF
--- a/spec/factories/hearings.rb
+++ b/spec/factories/hearings.rb
@@ -14,5 +14,11 @@ FactoryBot.define do
     after(:build) do |hearing|
       hearing.hearing_days << FactoryBot.create(:hearing_day)
     end
+
+    trait :with_prosecution_case do
+      after(:build) do |hearing|
+        hearing.prosecution_cases << FactoryBot.build(:prosecution_case)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

To return more realistic data from the mock to CDA, amend the `hearings` factory to add a trait so that a `prosecution_case` is created. This causes a `hearing_summary` to be created and included in the prosecution case search response.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
