### PR TITLE
Update defendant seeds with clearer values

### DIFF
--- a/spec/factories/applicant_counsels.rb
+++ b/spec/factories/applicant_counsels.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     firstName { 'John' }
     middleName { 'Random' }
     lastName { 'Rob' }
-    status { 'Random' }
+    status { 'Leading counsel' }
     after(:build) do |applicant_counsel|
       applicant_counsel.applicants << build(:applicant)
       applicant_counsel.attendance_days << build(:attendance_day)
@@ -18,7 +18,7 @@ FactoryBot.define do
     firstName { Faker::Name.first_name }
     middleName { Faker::Name.middle_name }
     lastName { Faker::Name.last_name }
-    status { Faker::Demographic.race }
+    status { "#{Faker::Job.seniority} counsel" }
     after(:build) do |applicant_counsel|
       applicant_counsel.applicants << build(:realistic_applicant, applicant_counsel: nil)
       applicant_counsel.attendance_days << build(:realistic_attendance_day)

--- a/spec/factories/defence_counsels.rb
+++ b/spec/factories/defence_counsels.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     firstName { 'John' }
     middleName { 'Random' }
     lastName { 'Rob' }
-    status { 'Random' }
+    status { 'Junior counsel' }
     after(:build) do |defence_counsel|
       defence_counsel.defendants << build(:defendant)
       defence_counsel.attendance_days << build(:attendance_day)
@@ -18,7 +18,7 @@ FactoryBot.define do
     firstName { Faker::Name.first_name }
     middleName { Faker::Name.middle_name }
     lastName { Faker::Name.last_name }
-    status { Faker::Demographic.race }
+    status { "#{Faker::Job.seniority} counsel" }
     after(:build) do |defence_counsel|
       defence_counsel.defendants << build(:realistic_defendant)
       defence_counsel.attendance_days << build(:realistic_attendance_day)

--- a/spec/factories/person_defendants.rb
+++ b/spec/factories/person_defendants.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     bailConditions { 'Random string' }
     bailReasons { 'Random string' }
     custodyTimeLimit { '2019-10-17 15:38:58' }
-    perceivedBirthYear { 1 }
+    perceivedBirthYear { 1999 }
     driverNumber { 'Random string' }
     driverLicenceCode { 'PROVISIONAL' }
     driverLicenseIssue { 'Random string' }
@@ -23,7 +23,7 @@ FactoryBot.define do
       association :employer_organisation, factory: :realistic_organisation
       bailConditions { Faker::Lorem.sentence }
       bailReasons { Faker::Lorem.sentence }
-      perceivedBirthYear { Faker::Number.between(from: 1, to: 75) }
+      perceivedBirthYear { Faker::Number.between(from: 1950, to: 2010) }
       driverNumber { Faker::Lorem.sentence }
       driverLicenceCode { PersonDefendant::LICENCE_CODES.sample }
       driverLicenseIssue { Faker::Lorem.sentence }


### PR DESCRIPTION
## What
Update seeds to have [real looking values](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/pull/79#discussion_r383226408)

Changed: 
ApplicantCounsel and DefendantCounsel to have a status similar to "Leading counsel"
PersonDefendant to have perceivedBirthYear between 1950 and 2020

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
