### PR TITLE
Amend factory national insurance number faker regex

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,7 +4,7 @@ class Person < ApplicationRecord
   LANGUAGES = %w[ENGLISH WELSH].freeze
   GENDERS = %w[MALE FEMALE NOT_KNOWN NOT_SPECIFIED].freeze
   TITLES = %w[MR MRS MISS MS].freeze
-  NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/.freeze
+  NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-D]{1}$/.freeze
 
   scope :by_name, ->(full_name) { where(full_name.slice(:firstName, :lastName, :middleName)) }
   scope :by_date_of_birth, ->(date) { where(dateOfBirth: date) }


### PR DESCRIPTION
To be inline with [schema regex definition](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/blob/6955ae92a00efe5adc924eba2f5aaf3e658b97f9/lib/schemas/global/courtsDefinitions.json#L213-L216)

Meant was generating random data with NI numbers that could not
be searched for adaptor and returning, for example:
```
{"error"=>"[\"The property '#/nationalInsuranceNumber' value \\\"HR669639M\\\" did not match the regex '(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\\\\s*\\\\d\\\\s*){6}([A-D]|\\\\s)$' in schema http://justice.gov.uk/unified_search_query/global/courtsDefinitions.json#\"]"}
```

## What

Amended regex for national insurance number so it generates
NINOs that are valid against the schema from hmcts Common platform

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
