### PR TITLE
Fix defendantDOB to match CP format

### DIFF
--- a/app/services/prosecution_case_search.rb
+++ b/app/services/prosecution_case_search.rb
@@ -17,7 +17,7 @@ class ProsecutionCaseSearch < ApplicationService
 
     return prosecution_cases_by_summons if permitted_params['defendantASN'].present?
 
-    return prosecution_cases_by_name_and_dob if permitted_params['dateOfBirth'].present?
+    return prosecution_cases_by_name_and_dob if permitted_params['defendantDOB'].present?
 
     prosecution_cases_by_name_and_date_of_next_hearing
   end
@@ -53,7 +53,7 @@ class ProsecutionCaseSearch < ApplicationService
   end
 
   def person_defendant_by_name_and_dob
-    PersonDefendant.by_name_and_dob(permitted_params.slice(:defendantName, :dateOfBirth))
+    PersonDefendant.by_name_and_dob(defendantName: permitted_params[:defendantName], dateOfBirth: permitted_params[:defendantDOB])
   end
 
   def prosecution_cases_by_name_and_date_of_next_hearing
@@ -70,7 +70,7 @@ class ProsecutionCaseSearch < ApplicationService
     params.permit(:prosecutionCaseReference,
                   :defendantNINO,
                   :defendantASN,
-                  :dateOfBirth,
+                  :defendantDOB,
                   :dateOfNextHearing,
                   :defendantName)
   end

--- a/lib/schemas/api/search-prosecutionCaseRequest.json
+++ b/lib/schemas/api/search-prosecutionCaseRequest.json
@@ -19,7 +19,7 @@
             "description": "The name of the defendant",
             "type": "string"
         },
-        "dateOfBirth": {
+        "defendantDOB": {
           "description": "The person date of birth when the defendant is a person",
           "$ref": "../../external/global/apiCourtsDefinitions.json#/definitions/datePattern"
         },
@@ -47,7 +47,7 @@
         {
           "required": [
             "defendantName",
-            "dateOfBirth"
+            "defendantDOB"
           ]
         },
         {

--- a/spec/services/prosecution_case_search_spec.rb
+++ b/spec/services/prosecution_case_search_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe ProsecutionCaseSearch do
     end
 
     let(:params_hash) do
-      { dateOfBirth: '2000-01-10', defendantName: 'John Doe' }
+      { defendantDOB: '2000-01-10', defendantName: 'John Doe' }
     end
 
     it { is_expected.to include(cases.first) }
@@ -128,7 +128,7 @@ RSpec.describe ProsecutionCaseSearch do
 
     context 'with a non matching reference' do
       let(:params_hash) do
-        { dateOfBirth: '2012-12-12', defendantName: 'John Doe' }
+        { defendantDOB: '2012-12-12', defendantName: 'John Doe' }
       end
 
       it { is_expected.to be_empty }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-297)

Change dateOfBirth to be defendantDOB to match CP format.
The schema changes have been sent across to HMCTS to review.

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
