### PR TITLE
Edit mock to match CP in SIT

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,3 @@
 LAA_ADAPTOR_URL=https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk
 LAA_ADAPTOR_AUTH_TOKEN=
-SHARED_SECRET_KEY_LAA_REFERENCE=super-secret-search-laa-reference-key
-SHARED_SECRET_KEY_REPRESENTATION_ORDER=super-secret-search-representation-order-key
-SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE=super-secret-search-prosecution-case-key
-SHARED_SECRET_KEY_HEARING=super-secret-hearing-key
+SHARED_SECRET_KEY=super-secret-key

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,11 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate
-    raise StandardError, 'authenticate must be defined by the controller'
+    authenticated = ActiveSupport::SecurityUtils.secure_compare(
+      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
+      ENV.fetch('SHARED_SECRET_KEY')
+    )
+
+    head :unauthorized unless authenticated
   end
 end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -8,7 +8,7 @@ class HearingsController < ApplicationController
   end
 
   def log
-    @hearing = HearingLogFinder.call(params)
+    @hearing_events = HearingLogFinder.call(params)
 
     render json: hearing_log_response
   end
@@ -16,11 +16,15 @@ class HearingsController < ApplicationController
   private
 
   def hearing_log_response
-    { hearingLog: hearing_events_builder }
+    {
+      "hearingId": params[:hearingId],
+      "hasActiveHearing": @hearing_events.present?,
+      "events": hearing_events_builder
+    }
   end
 
   def hearing_events_builder
-    @hearing.events.map do |event|
+    @hearing_events.map do |event|
       event.to_builder.attributes!
     end
   end

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -24,13 +24,4 @@ class HearingsController < ApplicationController
       event.to_builder.attributes!
     end
   end
-
-  def authenticate
-    authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
-      ENV.fetch('SHARED_SECRET_KEY_HEARING')
-    )
-
-    head :unauthorized unless authenticated
-  end
 end

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -10,28 +10,4 @@ class LaaReferencesController < ApplicationController
     @laa_reference = LaaRepresentationOrderRecorder.call(params)
     head :accepted
   end
-
-  private
-
-  def authenticate
-    send("authenticate_#{action_name}")
-  end
-
-  def authenticate_record_reference
-    authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
-      ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
-    )
-
-    head :unauthorized unless authenticated
-  end
-
-  def authenticate_record_representation_order
-    authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
-      ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
-    )
-
-    head :unauthorized unless authenticated
-  end
 end

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -4,6 +4,7 @@ class ProsecutionCasesController < ApplicationController
   def index
     @prosecution_cases = ProsecutionCaseSearch.call(params)
 
+    headers['Content-Type'] = 'application/vnd.unifiedsearch.query.laa.cases+json'
     render json: prosecution_cases_response
   end
 

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -18,13 +18,4 @@ class ProsecutionCasesController < ApplicationController
       ProsecutionCaseSummary.new(prosecution_case_id: prosecution_case_id).to_builder.attributes!
     end
   end
-
-  def authenticate
-    authenticated = ActiveSupport::SecurityUtils.secure_compare(
-      request.headers.fetch('Ocp-Apim-Subscription-Key', ''),
-      ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE')
-    )
-
-    head :unauthorized unless authenticated
-  end
 end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -46,7 +46,7 @@ class Defendant < ApplicationRecord
   }
 
   scope :by_date_of_next_hearing, lambda { |date|
-    joins(judicial_results: :next_hearing).where(next_hearings: { listedStartDateTime: date })
+    joins(judicial_results: :next_hearing).where(next_hearings: { listedStartDateTime: date.to_date.all_day })
   }
 
   def person?

--- a/app/models/person_defendant.rb
+++ b/app/models/person_defendant.rb
@@ -22,7 +22,7 @@ class PersonDefendant < ApplicationRecord
       person_defendant.bailStatus bail_status.to_builder if bail_status.present?
       person_defendant.bailConditions bailConditions
       person_defendant.bailReasons bailReasons
-      person_defendant.custodyTimeLimit custodyTimeLimit.to_date
+      person_defendant.custodyTimeLimit custodyTimeLimit&.to_date
       person_defendant.perceivedBirthYear perceivedBirthYear
       person_defendant.driverNumber driverNumber
       person_defendant.driverLicenceCode driverLicenceCode

--- a/app/services/hearing_log_finder.rb
+++ b/app/services/hearing_log_finder.rb
@@ -11,7 +11,7 @@ class HearingLogFinder < ApplicationService
     errors = JSON::Validator.fully_validate(schema, permitted_params.to_json)
     raise Errors::InvalidParams, errors if errors.present?
 
-    Hearing.find(params[:hearingId])
+    Hearing.find(params[:hearingId]).events.where(eventTime: params[:date].to_date.all_day)
   end
 
   private
@@ -19,7 +19,7 @@ class HearingLogFinder < ApplicationService
   attr_reader :params, :schema
 
   def permitted_params
-    params.permit(:hearingId)
+    params.permit(:hearingId, :date)
   end
 
   def register_dependant_schemas!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
     '/defendants/:defendantId' \
     '/offences/:offenceId' => 'laa_references#record_representation_order', as: :representation_order
   get '/LAAGetHearingHttpTrigger' => 'hearings#show', as: :hearing
-  get '/LAAGetHearingLogHttpTrigger' => 'hearings#log', as: :hearing_log
+  get '/LAAGetHearingEventLogHttpTriggerFast' => 'hearings#log', as: :hearing_log
 end

--- a/helm_deploy/hmcts-common-platform-mock-api/templates/deployment.yaml
+++ b/helm_deploy/hmcts-common-platform-mock-api/templates/deployment.yaml
@@ -56,26 +56,11 @@ spec:
                 secretKeyRef:
                   name: mock-api-secrets
                   key: laa-adaptor-auth-token
-            - name: SHARED_SECRET_KEY_LAA_REFERENCE
+            - name: SHARED_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: mock-api-secrets
-                  key: common-platform-laa-reference-key
-            - name: SHARED_SECRET_KEY_REPRESENTATION_ORDER
-              valueFrom:
-                secretKeyRef:
-                  name: mock-api-secrets
-                  key: common-platform-representation-order-key
-            - name: SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE
-              valueFrom:
-                secretKeyRef:
-                  name: mock-api-secrets
-                  key: common-platform-search-prosecution-case-key
-            - name: SHARED_SECRET_KEY_HEARING
-              valueFrom:
-                secretKeyRef:
-                  name: mock-api-secrets
-                  key: common-platform-hearing-key
+                  key: common-platform-key
             - name: LAA_ADAPTOR_URL
               value: {{ .Values.laa.adaptor_url }}
           resources:

--- a/lib/schemas/api/hearing.api.hearingEventLogRequest.json
+++ b/lib/schemas/api/hearing.api.hearingEventLogRequest.json
@@ -6,10 +6,14 @@
         "hearingId": {
           "description": "The identifier of the hearing",
           "$ref": "../../external/global/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "date": {
+          "description": "Date of the logs being requested",
+          "$ref": "../../external/global/apiCourtsDefinitions.json#/definitions/datePattern"
         }
     },
     "required": [
-        "hearingId"
+        "date"
       ],
     "additionalProperties": false
 }

--- a/lib/schemas/api/hearing.api.hearingEventLogResponse.json
+++ b/lib/schemas/api/hearing.api.hearingEventLogResponse.json
@@ -3,7 +3,14 @@
     "id": "http://justice.gov.uk/hearing/courts/api/hearingEventLogResponse.json",
     "type": "object",
     "properties": {
-        "hearingLog": {
+        "hearingId": {
+            "description": "The identifier of the hearing",
+            "$ref": "../../external/global/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "hasActiveHearing": {
+            "type": "boolean"
+        },
+        "events": {
         	"description": "The collection of hearing events that constitute the log",
 			"type": "array",
 			"minItems": 1,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    it 'raises a StandardError' do
-      expect do
-        get :index
-      end.to raise_error(StandardError, 'authenticate must be defined by the controller')
+    it 'returns unauthorized' do
+      get :index
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -19,15 +19,17 @@ RSpec.describe HearingsController, type: :controller do
   end
 
   describe 'GET #log' do
+    before { FactoryBot.create(:hearing_event, hearing: hearing, eventTime: '2020-12-12 03:30') }
+
     it 'returns unauthorized' do
-      get :log, params: { hearingId: hearing.id }
+      get :log, params: { hearingId: hearing.id, date: '2020-12-12' }
       expect(response).to be_unauthorized
     end
 
     context 'with the correct auth header' do
       it 'returns a success response' do
         request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
-        get :log, params: { hearingId: hearing.id }
+        get :log, params: { hearingId: hearing.id, date: '2020-12-12' }
         expect(response).to be_successful
       end
     end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe HearingsController, type: :controller do
 
     context 'with the correct auth header' do
       it 'returns a success response' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_HEARING')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         get :show, params: { hearingId: hearing.id }
         expect(response).to be_successful
       end
@@ -26,7 +26,7 @@ RSpec.describe HearingsController, type: :controller do
 
     context 'with the correct auth header' do
       it 'returns a success response' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_HEARING')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         get :log, params: { hearingId: hearing.id }
         expect(response).to be_successful
       end

--- a/spec/controllers/laa_references_controller_spec.rb
+++ b/spec/controllers/laa_references_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe LaaReferencesController, type: :controller do
       before { laa_reference.save! }
 
       it 'returns an accepted status' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         put :record_reference, params: laa_reference_params
         expect(response).to have_http_status(:accepted)
       end
@@ -45,7 +45,7 @@ RSpec.describe LaaReferencesController, type: :controller do
 
     context 'when the LaaReference is new' do
       it 'returns an accepted status' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_LAA_REFERENCE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         put :record_reference, params: laa_reference_params
         expect(response).to have_http_status(:accepted)
       end
@@ -80,7 +80,7 @@ RSpec.describe LaaReferencesController, type: :controller do
       before { laa_reference.save! }
 
       it 'returns an accepted status' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         put :record_representation_order, params: laa_reference_params
         expect(response).to have_http_status(:accepted)
       end
@@ -88,7 +88,7 @@ RSpec.describe LaaReferencesController, type: :controller do
 
     context 'when the LaaReference is new' do
       it 'returns an accepted status' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_REPRESENTATION_ORDER')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         put :record_representation_order, params: laa_reference_params
         expect(response).to have_http_status(:accepted)
       end

--- a/spec/controllers/prosecution_cases_controller_spec.rb
+++ b/spec/controllers/prosecution_cases_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProsecutionCasesController, type: :controller do
 
     context 'with the correct auth header' do
       it 'returns a success response' do
-        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE')
+        request.headers['Ocp-Apim-Subscription-Key'] = ENV.fetch('SHARED_SECRET_KEY')
         get :index, params: { prosecutionCaseReference: 'some reference' }
         expect(response).to be_successful
       end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Defendant, type: :model do
 
       subject { described_class.by_date_of_next_hearing(next_hearing_date) }
 
-      let!(:defendant_one) { FactoryBot.create(:defendant, :with_next_hearing, next_hearing_date: '2020-01-10') }
+      let!(:defendant_one) { FactoryBot.create(:defendant, :with_next_hearing, next_hearing_date: '2020-01-10 12:30') }
       let!(:defendant_two) { FactoryBot.create(:defendant) }
 
       it { is_expected.to include(defendant_one) }

--- a/spec/models/person_defendant_spec.rb
+++ b/spec/models/person_defendant_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe PersonDefendant, type: :model do
   context 'hmcts schema' do
     it_has_behaviour 'conforming to valid schema'
 
+    context 'required attributes' do
+      before { person_defendant.update!(custodyTimeLimit: nil) }
+
+      it_has_behaviour 'conforming to valid schema'
+    end
+
     context 'with relationships' do
       let(:person_defendant) { FactoryBot.create(:person_defendant_with_relationships) }
 

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe 'Hearings', type: :request do
     end
   end
 
-  describe 'GET /LAAGetHearingLogHttpTrigger' do
-    before { FactoryBot.create(:hearing_event, hearing: hearing) }
+  describe 'GET /LAAGetHearingEventLogHttpTriggerFast' do
+    before { FactoryBot.create(:hearing_event, hearing: hearing, eventTime: '2020-12-12 03:30') }
 
     it 'matches the response schema' do
-      get "/LAAGetHearingLogHttpTrigger?hearingId=#{hearing.id}", headers: headers
+      get "/LAAGetHearingEventLogHttpTriggerFast?hearingId=#{hearing.id}&date=2020-12-12", headers: headers
       expect(response).to have_http_status(200)
       expect(response.body).to match_json_schema(:results_hearing_event_log_response)
     end

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'Hearings', type: :request do
   let(:hearing) { FactoryBot.create(:hearing) }
-  let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_HEARING') } }
+  let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY') } }
 
   describe 'GET /LAAGetHearingHttpTrigger' do
     it 'matches the response schema' do

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'ProsecutionCases', type: :request do
-  let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE') } }
+  let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch('SHARED_SECRET_KEY') } }
 
   describe 'GET /prosecutionCases' do
     let!(:prosecution_case) do

--- a/spec/requests/prosecution_cases_spec.rb
+++ b/spec/requests/prosecution_cases_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'ProsecutionCases', type: :request do
     it 'matches the response schema' do
       get '/prosecutionCases?prosecutionCaseReference=some-reference', headers: headers
       expect(response).to have_http_status(200)
+      expect(response.headers['content-type']).to eq('application/vnd.unifiedsearch.query.laa.cases+json')
       expect(response.body).to match_json_schema(:search_prosecution_case_response)
     end
 
@@ -20,6 +21,7 @@ RSpec.describe 'ProsecutionCases', type: :request do
       it 'matches the response schema' do
         get '/prosecutionCases?prosecutionCaseReference=incorrect-reference', headers: headers
         expect(response).to have_http_status(200)
+        expect(response.headers['content-type']).to eq('application/vnd.unifiedsearch.query.laa.cases+json')
         expect(response.body).to match_json_schema(:search_prosecution_case_response)
       end
     end

--- a/spec/services/hearing_log_finder_spec.rb
+++ b/spec/services/hearing_log_finder_spec.rb
@@ -18,17 +18,18 @@ RSpec.describe HearingLogFinder do
   end
 
   context 'when finding by hearingId' do
-    let(:hearing) { FactoryBot.create(:hearing) }
+    let(:hearing_event) { FactoryBot.create(:hearing_event) }
+    let(:hearing) { hearing_event.hearing }
 
     let(:params_hash) do
-      { hearingId: hearing.id }
+      { hearingId: hearing.id, date: '2020-04-23' }
     end
 
-    it { is_expected.to eq(hearing) }
+    it { is_expected.to eq([hearing_event]) }
 
     context 'with an incorrect id' do
       let(:params_hash) do
-        { hearingId: '6c0b7068-d4a7-4adc-a7a0-7bd5715b501d' }
+        { hearingId: '6c0b7068-d4a7-4adc-a7a0-7bd5715b501d', date: '2020-04-23' }
       end
 
       it 'raises a RecordNotFound error' do


### PR DESCRIPTION
## What
This PR is necessary to support changes done in https://github.com/ministryofjustice/laa-court-data-adaptor/pull/157

[Link to story](https://dsdmoj.atlassian.net/browse/CACP-368)
Edits the mock to allow it to work with CDA, incorporating hearing events changes and more closely matching CP SIT.
1. Modifed the schema to match Hearing logs endpoint: The endpoint requires a date + hearing id, as seen in CP SIT. This will be confirmed with HMCTS.
2. Refactored to move authentication to application controller as all the endpoints use the same key now.
3. In the Prosecution case search, edited the Content-type header value to `application/vnd.unifiedsearch.query.laa.cases+json` as seen in SIT
4. Allowed PersonDefendant.custodyTimeLimit value to be optional. 
5. Fetch Hearings by next_hearing full day range, rather than exact time matches
6. Edited Hearing Log endpoint to match CP SIT (implementation based on point 1)

## Checklist

Before you ask people to review this PR:

- [X] Tests and linters should be passing
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
