### PR TITLE
Match GET Hearings output to CP SIT

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -4,7 +4,7 @@ class HearingsController < ApplicationController
   def show
     @hearing = HearingFinder.call(params)
 
-    render json: @hearing.to_builder.attributes!
+    render json: { hearing: @hearing.to_builder.attributes!, sharedTime: @hearing.created_at.to_datetime }
   end
 
   def log

--- a/lib/schemas/api/results.api.hearingResultedResponse.json
+++ b/lib/schemas/api/results.api.hearingResultedResponse.json
@@ -2,7 +2,15 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://justice.gov.uk/results/courts/api/hearingResultedResponse.json",
     "type": "object",
-    "allOf": [{
-        "$ref": "../../external/global/apiHearing.json"
-    }]
+    "properties": {
+        "hearing": {
+            "description": "The details of the resulted hearing, its case details and the results",
+            "$ref": "../../external/global/apiHearing.json#"
+        },
+        "sharedTime": {
+            "description": "The date and time that teh results were shared by HMCTS",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": false
 }


### PR DESCRIPTION
## What
CP wraps the responses in a json object containg `hearing` and `sharedTime`
This change makes the mock output match the SIT format.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
