### PR TITLE
Convert ProsecutionCase <> Hearing relationship to a has many through to reflect the CP structure more accurately

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,3 +84,6 @@ RSpec/ImplicitSubject:
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+Style/RedundantFetchBlock:
+  Enabled: true

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -5,7 +5,8 @@ class Hearing < ApplicationRecord
   belongs_to :court_centre
   belongs_to :hearing_type
   belongs_to :cracked_ineffective_trial, optional: true
-  has_many :prosecution_cases
+  has_many :prosecution_case_hearings, dependent: :destroy
+  has_many :prosecution_cases, through: :prosecution_case_hearings
   has_many :court_applications
   has_many :referral_reasons
   has_many :hearing_case_notes

--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -8,7 +8,8 @@ class ProsecutionCase < ApplicationRecord
   belongs_to :prosecution_case_identifier
   belongs_to :police_officer_in_case, optional: true
   belongs_to :merged_prosecution_case, optional: true
-  belongs_to :hearing, optional: true, inverse_of: :prosecution_cases
+  has_many :prosecution_case_hearings, dependent: :destroy
+  has_many :hearings, through: :prosecution_case_hearings
 
   has_many :defendants, dependent: :destroy, inverse_of: :prosecution_case
   has_many :person_only_defendants, -> { people_only }, class_name: 'Defendant'

--- a/app/models/prosecution_case_hearing.rb
+++ b/app/models/prosecution_case_hearing.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ProsecutionCaseHearing < ApplicationRecord
+  belongs_to :prosecution_case
+  belongs_to :hearing
+end

--- a/app/models/prosecution_case_summary.rb
+++ b/app/models/prosecution_case_summary.rb
@@ -17,7 +17,7 @@ class ProsecutionCaseSummary
       prosecution_case_summary.prosecutionCaseReference prosecution_case_reference
       prosecution_case_summary.caseStatus prosecution_case.caseStatus
       prosecution_case_summary.defendantSummary defendants_builder
-      prosecution_case_summary.hearingSummary hearings_builder if prosecution_case.hearing_id.present?
+      prosecution_case_summary.hearingSummary hearings_builder if prosecution_case.hearings.present?
     end
   end
 
@@ -28,7 +28,7 @@ class ProsecutionCaseSummary
   end
 
   def hearings_builder
-    [HearingSummary.new(hearing_id: prosecution_case.hearing_id).to_builder.attributes!]
+    prosecution_case.hearings.map { |hearing| HearingSummary.new(hearing_id: hearing.id).to_builder.attributes! }
   end
 
   def defendants_builder

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,20 +6,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch('PORT') { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/db/migrate/20200703152351_create_prosecution_case_hearings.rb
+++ b/db/migrate/20200703152351_create_prosecution_case_hearings.rb
@@ -1,0 +1,20 @@
+class CreateProsecutionCaseHearings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :prosecution_case_hearings, id: :uuid do |t|
+      t.references :prosecution_case, type: :uuid, null: false, foreign_key: true
+      t.references :hearing, type: :uuid, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+        INSERT INTO prosecution_case_hearings (prosecution_case_id, hearing_id, created_at, updated_at)
+        SELECT id, hearing_id, created_at, updated_at FROM prosecution_cases;
+        SQL
+      end
+    end
+
+    remove_reference :prosecution_cases, :hearing, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_112230) do
+ActiveRecord::Schema.define(version: 2020_07_03_152351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -958,6 +958,15 @@ ActiveRecord::Schema.define(version: 2020_05_19_112230) do
     t.index ["prosecution_case_id"], name: "prosecution_case_hearing_case_notes_on_prosecution_case_id"
   end
 
+  create_table "prosecution_case_hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "prosecution_case_id", null: false
+    t.uuid "hearing_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hearing_id"], name: "index_prosecution_case_hearings_on_hearing_id"
+    t.index ["prosecution_case_id"], name: "index_prosecution_case_hearings_on_prosecution_case_id"
+  end
+
   create_table "prosecution_case_identifiers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "caseURN"
     t.string "prosecutionAuthorityReference"
@@ -981,9 +990,7 @@ ActiveRecord::Schema.define(version: 2020_05_19_112230) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "prosecution_counsel_id"
-    t.uuid "hearing_id"
     t.string "removalReason"
-    t.index ["hearing_id"], name: "index_prosecution_cases_on_hearing_id"
     t.index ["merged_prosecution_case_id"], name: "index_prosecution_cases_on_merged_prosecution_case_id"
     t.index ["police_officer_in_case_id"], name: "index_prosecution_cases_on_police_officer_in_case_id"
     t.index ["prosecution_case_identifier_id"], name: "index_prosecution_cases_on_prosecution_case_identifier_id"
@@ -1183,7 +1190,8 @@ ActiveRecord::Schema.define(version: 2020_05_19_112230) do
   add_foreign_key "prosecuting_authorities", "contact_numbers", column: "contact_id"
   add_foreign_key "prosecution_case_hearing_case_notes", "hearing_case_notes"
   add_foreign_key "prosecution_case_hearing_case_notes", "prosecution_cases"
-  add_foreign_key "prosecution_cases", "hearings"
+  add_foreign_key "prosecution_case_hearings", "hearings"
+  add_foreign_key "prosecution_case_hearings", "prosecution_cases"
   add_foreign_key "prosecution_cases", "merged_prosecution_cases"
   add_foreign_key "prosecution_cases", "police_officer_in_cases"
   add_foreign_key "prosecution_cases", "prosecution_case_identifiers"

--- a/spec/factories/prosecution_case_hearings.rb
+++ b/spec/factories/prosecution_case_hearings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :prosecution_case_hearing do
+    prosecution_case
+    hearing
+  end
+end

--- a/spec/factories/prosecution_case_identifiers.rb
+++ b/spec/factories/prosecution_case_identifiers.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :prosecution_case_identifier do
-    caseURN { '3658e889-e050-4608-8f21-8bdaa529f8d0' }
+    caseURN { 'INHRBICZKQ' }
     prosecutionAuthorityId { '91c0e6c7-4a4f-415b-a3e1-aea9883f6065' }
     prosecutionAuthorityCode { 'S5589083J' }
     factory :prosecution_case_identifier_with_reference do

--- a/spec/factories/prosecution_cases.rb
+++ b/spec/factories/prosecution_cases.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
     association :merged_prosecution_case, factory: :realistic_merged_prosecution_case
 
     after(:build) do |prosecution_case|
+      prosecution_case.hearings << build_list(:hearing, (0..2).to_a.sample)
       prosecution_case.defendants << build(:realistic_defendant, prosecution_case: nil)
       prosecution_case.markers << build_list(:realistic_marker, (0..3).to_a.sample)
       prosecution_case.split_prosecutor_case_references << build_list(:realistic_split_prosecutor_case_reference,

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Hearing, type: :model do
     it { should belong_to(:court_centre).class_name('CourtCentre') }
     it { should belong_to(:hearing_type).class_name('HearingType') }
     it { should belong_to(:cracked_ineffective_trial).class_name('CrackedIneffectiveTrial').optional }
-    it { should have_many(:prosecution_cases).class_name('ProsecutionCase') }
+    it { should have_many(:prosecution_case_hearings).class_name('ProsecutionCaseHearing') }
+    it { should have_many(:prosecution_cases).class_name('ProsecutionCase').through(:prosecution_case_hearings) }
     it { should have_many(:court_applications).class_name('CourtApplication') }
     it { should have_many(:referral_reasons).class_name('ReferralReason') }
     it { should have_many(:hearing_case_notes).class_name('HearingCaseNote') }

--- a/spec/models/prosecution_case_hearing_spec.rb
+++ b/spec/models/prosecution_case_hearing_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe ProsecutionCaseHearing, type: :model do
+  describe 'associations' do
+    it { should belong_to(:hearing).class_name('Hearing') }
+    it { should belong_to(:prosecution_case).class_name('ProsecutionCase') }
+  end
+end

--- a/spec/models/prosecution_case_spec.rb
+++ b/spec/models/prosecution_case_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe ProsecutionCase, type: :model do
   subject { prosecution_case }
 
   describe 'associations' do
-    it { should belong_to(:hearing).class_name('Hearing').optional }
+    it { should have_many(:prosecution_case_hearings).class_name('ProsecutionCaseHearing') }
+    it { should have_many(:hearings).class_name('Hearing').through(:prosecution_case_hearings) }
     it { should belong_to(:prosecution_case_identifier).class_name('ProsecutionCaseIdentifier') }
     it { should belong_to(:police_officer_in_case).class_name('PoliceOfficerInCase').optional }
     it { should belong_to(:merged_prosecution_case).class_name('MergedProsecutionCase').optional }
@@ -58,6 +59,7 @@ RSpec.describe ProsecutionCase, type: :model do
 
   context 'with relationships' do
     before do
+      prosecution_case.hearings << build(:hearing)
       prosecution_case.police_officer_in_case = build(:police_officer_in_case)
       prosecution_case.merged_prosecution_case = build(:merged_prosecution_case)
       prosecution_case.defendants << build(:defendant)

--- a/spec/models/prosecution_case_summary_spec.rb
+++ b/spec/models/prosecution_case_summary_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe ProsecutionCaseSummary, type: :model do
 
   context 'with a hearing relationship' do
     before do
-      prosecution_case.update!(hearing: FactoryBot.create(:hearing))
+      prosecution_case.hearings << FactoryBot.create(:hearing)
+      prosecution_case.save!
     end
 
     it_has_behaviour 'conforming to valid schema'


### PR DESCRIPTION
## What

Since CP schema allows multiple hearings to be sent as part of a `ProsecutionCase` search payload, this PR maps the relationship a bit more accurately. 
## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
