### PR TITLE
Add safe navigation to `.to_date` calls in offence jbuilder

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -36,11 +36,11 @@ class Offence < ApplicationRecord
       offence.wording wording
       offence.wordingWelsh wordingWelsh
       offence.startDate startDate.to_date
-      offence.endDate endDate.to_date
-      offence.arrestDate arrestDate.to_date
-      offence.chargeDate chargeDate.to_date
-      offence.laidDate laidDate.to_date
-      offence.dateOfInformation dateOfInformation.to_date
+      offence.endDate endDate&.to_date
+      offence.arrestDate arrestDate&.to_date
+      offence.chargeDate chargeDate&.to_date
+      offence.laidDate laidDate&.to_date
+      offence.dateOfInformation dateOfInformation&.to_date
       offence.orderIndex orderIndex
       offence.count count
       offence.convictionDate convictionDate.to_date


### PR DESCRIPTION
## What
Add safe navigation to `.to_date` calls in offence jbuilder

## Why
Was erroring when calling hearing endpoint


## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.