### PR TITLE
Amend migration to handle prosecution cases with no hearings

### DIFF
--- a/db/migrate/20200703152351_create_prosecution_case_hearings.rb
+++ b/db/migrate/20200703152351_create_prosecution_case_hearings.rb
@@ -10,7 +10,9 @@ class CreateProsecutionCaseHearings < ActiveRecord::Migration[6.0]
       dir.up do
         execute <<-SQL
         INSERT INTO prosecution_case_hearings (prosecution_case_id, hearing_id, created_at, updated_at)
-        SELECT id, hearing_id, created_at, updated_at FROM prosecution_cases;
+        SELECT id, hearing_id, created_at, updated_at
+        FROM prosecution_cases
+        WHERE hearing_id IS NOT NULL;
         SQL
       end
     end


### PR DESCRIPTION
## What
Amend migration to handle prosecution cases with no hearings

## Why
Currently running the migration in my environment
results in constraint violation as the select is returning
prosecution cases without a hearing, and hearing_id cannot
be null.


## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.