### PR TITLE
Expose hearing_days startTime attribute

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -13,6 +13,7 @@ class HearingDay < ApplicationRecord
   def to_builder
     Jbuilder.new do |hearing_day|
       hearing_day.sittingDay sittingDay
+      hearing_day.startTime startTime
       hearing_day.listingSequence listingSequence
       hearing_day.listedDurationMinutes listedDurationMinutes
     end

--- a/lib/schemas/global/apiHearingDay.json
+++ b/lib/schemas/global/apiHearingDay.json
@@ -7,6 +7,10 @@
             "type": "string",
             "format": "date-time"
         },
+        "startTime": {
+            "type": "string",
+            "format": "date-time"
+        },
         "listingSequence": {
             "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/positiveInteger"
         },

--- a/spec/factories/hearing_days.rb
+++ b/spec/factories/hearing_days.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :hearing_day do
     sittingDay { '2019-10-23 16:19:15' }
+    startTime { '2000-01-01 07:30:00' }
     listingSequence { 1 }
     listedDurationMinutes { 1 }
   end

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe HearingDay, type: :model do
   context 'hmcts schema' do
     it_has_behaviour 'conforming to valid schema'
   end
+
+  describe '#to_builder' do
+    subject { hearing_day.to_builder.attributes! }
+
+    it { is_expected.to include('sittingDay', 'startTime', 'listingSequence', 'listedDurationMinutes') }
+  end
 end


### PR DESCRIPTION
expose hearing day startTime for use as "Time listed"

## What
needed as the "Time listed" in VCD?! This is assuming
this is the right source for a hearings "Time listed".

It is being used by hearing_time attribute in CDA hearing endpoint
but is never actually returned by the mock.


## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.