### PR TITLE
Add length constraints to offenceCode

### DIFF
--- a/app/models/lesser_or_alternative_offence.rb
+++ b/app/models/lesser_or_alternative_offence.rb
@@ -2,7 +2,7 @@
 
 class LesserOrAlternativeOffence < ApplicationRecord
   validates :offenceDefinitionId, presence: true
-  validates :offenceCode, presence: true
+  validates :offenceCode, presence: true, length: { maximum: 8 }
   validates :offenceTitle, presence: true
   validates :offenceLegislation, presence: true
 

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -16,7 +16,7 @@ class Offence < ApplicationRecord
   has_one :laa_reference, dependent: :destroy
 
   validates :offenceDefinitionId, presence: true
-  validates :offenceCode, presence: true
+  validates :offenceCode, presence: true, length: { maximum: 8 }
   validates :offenceTitle, presence: true
   validates :wording, presence: true
   validates :startDate, presence: true

--- a/db/migrate/20200803133825_change_offence_code_value.rb
+++ b/db/migrate/20200803133825_change_offence_code_value.rb
@@ -1,0 +1,10 @@
+class ChangeOffenceCodeValue < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute 'UPDATE offences SET "offenceCode" = \'PT00011\';'
+        execute 'UPDATE lesser_or_alternative_offences SET "offenceCode" = \'PT00011\';'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_144044) do
+ActiveRecord::Schema.define(version: 2020_08_03_133825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories/lesser_or_alternative_offences.rb
+++ b/spec/factories/lesser_or_alternative_offences.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :lesser_or_alternative_offence do
     offenceDefinitionId { SecureRandom.uuid }
-    offenceCode { 'MyString' }
+    offenceCode { 'RC86395' }
     offenceTitle { 'MyString' }
     offenceTitleWelsh { 'MyString' }
     offenceLegislation { 'MyString' }
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     factory :realistic_lesser_or_alternative_offence do
       offenceDefinitionId { SecureRandom.uuid }
-      offenceCode { Faker::Lorem.sentence }
+      offenceCode { Faker::Alphanumeric.alphanumeric(number: 6).upcase }
       offenceTitle { Faker::Lorem.word }
       offenceTitleWelsh { Faker::Lorem.word }
       offenceLegislation { Faker::Lorem.sentence }

--- a/spec/factories/offences.rb
+++ b/spec/factories/offences.rb
@@ -5,7 +5,7 @@ require 'faker/offence'
 FactoryBot.define do
   factory :offence, aliases: [:realistic_offence] do
     offenceDefinitionId { SecureRandom.uuid }
-    offenceCode { 'Random string' }
+    offenceCode { 'PT00011' }
     dvlaCode { 'Random string' }
     offenceTitle { Faker::Offence.name }
     offenceTitleWelsh { Faker::Offence.name }

--- a/spec/models/lesser_or_alternative_offence_spec.rb
+++ b/spec/models/lesser_or_alternative_offence_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe LesserOrAlternativeOffence, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:offenceDefinitionId) }
     it { should validate_presence_of(:offenceCode) }
+    it { should validate_length_of(:offenceCode).is_at_most(8) }
     it { should validate_presence_of(:offenceTitle) }
     it { should validate_presence_of(:offenceLegislation) }
   end

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Offence, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:offenceDefinitionId) }
     it { should validate_presence_of(:offenceCode) }
+    it { should validate_length_of(:offenceCode).is_at_most(8) }
     it { should validate_presence_of(:offenceTitle) }
     it { should validate_presence_of(:wording) }
     it { should validate_presence_of(:startDate) }


### PR DESCRIPTION
## What
Limit OffenceCode to max 8 characters. 
To ensure compatibility with the format expected by MLRA:
```
Caused by: oracle.jdbc.OracleDatabaseException: ORA-12899: value too large for column "MLA"."XXMLA_XLAT_OFFENCE"."OFFENCE_CODE" (actual: 13, maximum: 8)
2020-08-03T12:30:41.764+01:00
```

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
