### PR TITLE
Cacp 502 cp mock to render name breakdown

### DIFF
--- a/app/models/defendant_summary.rb
+++ b/app/models/defendant_summary.rb
@@ -16,7 +16,9 @@ class DefendantSummary
       defendant_summary.defendantId defendant_id
       defendant_summary.defendantNINO defendant.defendable.person.nationalInsuranceNumber if defendant.person?
       defendant_summary.defendantASN defendant.defendable.arrestSummonsNumber if defendant.person?
-      defendant_summary.defendantName defendant_name
+      defendant_summary.defendantFirstName defendant_first_name
+      defendant_summary.defendantMiddleName defendant_middle_name
+      defendant_summary.defendantLastName defendant_last_name
       defendant_summary.defendantDOB defendant.defendable.person.dateOfBirth.to_date if defendant.person?
       defendant_summary.dateOfNextHearing date_of_next_hearing
       defendant_summary.proceedingsConcluded proceedings_concluded?
@@ -36,8 +38,20 @@ class DefendantSummary
     defendant.offences.map(&:isDisposed).all? true
   end
 
-  def defendant_name
-    return defendant.defendable.person.name if defendant.person?
+  def defendant_first_name
+    return defendant.defendable.person.first_name if defendant.person?
+
+    defendant.defendable.organisation.name
+  end
+
+  def defendant_middle_name
+    return defendant.defendable.person.middle_name if defendant.person?
+
+    defendant.defendable.organisation.name
+  end
+
+  def defendant_last_name
+    return defendant.defendable.person.last_name if defendant.person?
 
     defendant.defendable.organisation.name
   end

--- a/app/models/defendant_summary.rb
+++ b/app/models/defendant_summary.rb
@@ -14,12 +14,17 @@ class DefendantSummary
   def to_builder
     Jbuilder.new do |defendant_summary|
       defendant_summary.defendantId defendant_id
-      defendant_summary.defendantNINO defendant.defendable.person.nationalInsuranceNumber if defendant.person?
-      defendant_summary.defendantASN defendant.defendable.arrestSummonsNumber if defendant.person?
-      defendant_summary.defendantFirstName defendant_first_name
-      defendant_summary.defendantMiddleName defendant_middle_name
-      defendant_summary.defendantLastName defendant_last_name
-      defendant_summary.defendantDOB defendant.defendable.person.dateOfBirth.to_date if defendant.person?
+      if defendant.person?
+        defendant_summary.defendantNINO defendant.defendable.person.nationalInsuranceNumber
+        defendant_summary.defendantASN defendant.defendable.arrestSummonsNumber
+        defendant_summary.defendantFirstName defendant_first_name
+        defendant_summary.defendantMiddleName defendant_middle_name
+        defendant_summary.defendantLastName defendant_last_name
+        defendant_summary.defendantDOB defendant.defendable.person.dateOfBirth.to_date
+      else
+        defendant_summary.defendantName defendant_name
+      end
+
       defendant_summary.dateOfNextHearing date_of_next_hearing
       defendant_summary.proceedingsConcluded proceedings_concluded?
       defendant_summary.offenceSummary offences_builder
@@ -38,22 +43,20 @@ class DefendantSummary
     defendant.offences.map(&:isDisposed).all? true
   end
 
-  def defendant_first_name
-    return defendant.defendable.person.first_name if defendant.person?
-
+  def defendant_name
     defendant.defendable.organisation.name
+  end
+
+  def defendant_first_name
+    defendant.defendable.person.first_name
   end
 
   def defendant_middle_name
-    return defendant.defendable.person.middle_name if defendant.person?
-
-    defendant.defendable.organisation.name
+    defendant.defendable.person.middle_name
   end
 
   def defendant_last_name
-    return defendant.defendable.person.last_name if defendant.person?
-
-    defendant.defendable.organisation.name
+    defendant.defendable.person.last_name
   end
 
   def offences_builder

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -20,8 +20,16 @@ class Person < ApplicationRecord
   validates :gender, presence: true, inclusion: GENDERS
   validates :documentationLanguageNeeds, inclusion: LANGUAGES
 
-  def name
-    [firstName, middleName, lastName].compact.join(' ')
+  def first_name
+    firstName
+  end
+
+  def middle_name
+    middleName
+  end
+
+  def last_name
+    lastName
   end
 
   def to_builder

--- a/lib/schemas/global/search/apiDefendantSummary.json
+++ b/lib/schemas/global/search/apiDefendantSummary.json
@@ -16,6 +16,10 @@
           "description": "The police arrest summons number when the defendant is a person",
           "type": "string"
         },
+        "defendantName": {
+          "description": "The name of the defendant",
+          "type": "string"
+        },
         "defendantFirstName": {
           "description": "The firstname of the defendant",
           "type": "string"
@@ -49,12 +53,23 @@
             }
         }
     },
-    "required": [
-        "defendantId",
-        "defendantFirstName",
-        "defendantMiddleName",
-        "defendantLastName",
-        "offenceSummary"
-    ],
+    "oneOf": [
+       {
+            "required": [
+              "defendantId",
+              "defendantName",
+              "offenceSummary"
+           ]
+       },
+       {
+            "required": [
+              "defendantId",
+              "defendantFirstName",
+              "defendantMiddleName",
+              "defendantLastName",
+              "offenceSummary"
+           ]
+       }
+   ],
     "additionalProperties": false
 }

--- a/lib/schemas/global/search/apiDefendantSummary.json
+++ b/lib/schemas/global/search/apiDefendantSummary.json
@@ -16,8 +16,16 @@
           "description": "The police arrest summons number when the defendant is a person",
           "type": "string"
         },
-        "defendantName": {
-          "description": "The name of the defendant",
+        "defendantFirstName": {
+          "description": "The firstname of the defendant",
+          "type": "string"
+        },
+        "defendantMiddleName": {
+          "description": "The middle name of the defendant",
+          "type": "string"
+        },
+        "defendantLastName": {
+          "description": "The last name of the defendant",
           "type": "string"
         },
         "defendantDOB": {
@@ -43,7 +51,9 @@
     },
     "required": [
         "defendantId",
-        "defendantName",
+        "defendantFirstName",
+        "defendantMiddleName",
+        "defendantLastName",
         "offenceSummary"
     ],
     "additionalProperties": false

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -74,22 +74,22 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  describe '#name' do
-    subject { person.name }
+  describe '#first_name' do
+    subject { person.first_name }
 
-    it { is_expected.to eq('Alfredine Treutel Parker') }
+    it { is_expected.to eq('Alfredine') }
+  end
 
-    context 'missing first name' do
-      before { person.update!(middleName: nil) }
+  describe '#middle_name' do
+    subject { person.middle_name }
 
-      it { is_expected.to eq('Alfredine Parker') }
-    end
+    it { is_expected.to eq('Treutel') }
+  end
 
-    context 'missing first and middle name' do
-      before { person.update!(firstName: nil, middleName: nil) }
+  describe '#last_name' do
+    subject { person.last_name }
 
-      it { is_expected.to eq('Parker') }
-    end
+    it { is_expected.to eq('Parker') }
   end
 
   it_has_behaviour 'conforming to valid schema'


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=398&projectKey=CACP&modal=detail&selectedIssue=CACP-502

Break down Defendant name to be displayed as separate fields of first/middle/last name when the Defendant is a person.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
