### PR TITLE
Cacp 511 auto populate when adding new offence

### DIFF
--- a/app/controllers/admin/prosecution_cases_controller.rb
+++ b/app/controllers/admin/prosecution_cases_controller.rb
@@ -48,6 +48,10 @@ module Admin
       end
     end
 
+    def add_offence
+      @prosecution_case = FactoryBot.build(:realistic_prosecution_case)
+    end
+
     private
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,7 +14,7 @@
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
-
+require('@rails/ujs').start()
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 import "@kollegorna/cocoon-vanilla-js";

--- a/app/views/admin/prosecution_cases/_add_offence.html.erb
+++ b/app/views/admin/prosecution_cases/_add_offence.html.erb
@@ -1,0 +1,9 @@
+<%= fields_for @prosecution_case do |prosecution_case_form| %>
+  <%= prosecution_case_form.fields_for :defendants do |defendant_form| %>
+    <%= defendant_form.fields_for :offences do |form| %>
+
+      <%= render 'offence_fields', f: form %>
+
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/prosecution_cases/_defendant.html.erb
+++ b/app/views/admin/prosecution_cases/_defendant.html.erb
@@ -175,8 +175,8 @@
     <%= defendant.fields_for :offences do |offence| %>
       <%= render 'offence_fields', f: offence %>
     <% end %>
-    <div class="links">
-      <%= link_to_add_association 'add offence', defendant, :offences %>
-    </div>
+  </div>
+  <div class="links">
+    <%= link_to 'add offence', add_offence_admin_prosecution_cases_path, remote: true %>
   </div>
 <% end %>

--- a/app/views/admin/prosecution_cases/add_offence.js.erb
+++ b/app/views/admin/prosecution_cases/add_offence.js.erb
@@ -1,0 +1,3 @@
+document.
+getElementById("offences").
+insertAdjacentHTML('beforeend', '<%= escape_javascript(render 'add_offence') %>')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
       member do
         post 'result/:hearing_id(/:publish_to)' => 'prosecution_cases#result', as: :result_hearing
       end
+      collection do
+        get 'add_offence'
+      end
     end
   end
   resources :status, only: [:index]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@kollegorna/cocoon-vanilla-js": "^1.0.6",
+    "@rails/ujs": "^6.0.3-3",
     "@rails/webpacker": "4.2.2",
     "cocoon-js-vanilla": "^1.1.0"
   },

--- a/spec/requests/admin/prosecution_cases_spec.rb
+++ b/spec/requests/admin/prosecution_cases_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe '/admin/prosecution_cases', type: :request do
     end
   end
 
+  describe 'GET /add_offence' do
+    it 'renders a successful response' do
+      get add_offence_admin_prosecution_cases_url, headers: headers, xhr: true
+      expect(response).to be_successful
+    end
+  end
+
   describe 'GET /edit' do
     it 'render a successful response' do
       get edit_admin_prosecution_case_url(prosecution_case), headers: headers

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,11 @@
   resolved "https://registry.yarnpkg.com/@kollegorna/cocoon-vanilla-js/-/cocoon-vanilla-js-1.0.6.tgz#37a54550936a57d8dcdb99e63340d379bb99589d"
   integrity sha512-DeGUU6GKdpE1QBz6FS35u4E5JPYcwiP8ZsrmUquhjCKNXNbQ7EKhBwprF9DyUpZ2NYGVgkwYof8b4iAPx0X9bg==
 
+"@rails/ujs@^6.0.3-3":
+  version "6.0.3-3"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.3-3.tgz#5cf1e99c6fa1beaf73d4bcac6ab9b05702e92713"
+  integrity sha512-bXCbtpSwCtqhBXxxoD5FGiyeqJU1smf4DS15SCXRzzSaoee2Kk+lVV5q2dEIBdj0NBDiK/G1ShoM2wlPy7Tu5w==
+
 "@rails/webpacker@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.2.2.tgz#b9dd3235fdf4d0badbda8e33f6ebee742a9f3abb"


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/CACP-511

Include ability to add additional offences to prosecution case with auto populated form to enable testing of different scenarios

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
