### PR TITLE
Add allocation decisions to demo data

### DIFF
--- a/lib/tasks/demo_data_helper.rb
+++ b/lib/tasks/demo_data_helper.rb
@@ -28,4 +28,21 @@ module DemoDataHelper
   def humanize_prosecution_case(pcase)
     pcase.prosecution_case_identifier.caseURN || pcase.prosecution_case_identifier.prosecutionAuthorityReference
   end
+
+  def case_details_hash(urn)
+    pc = prosecution_cases_by_reference(urn).first
+
+    pc.defendants.map do |d|
+      d.offences.map do |offence|
+        {
+          defendant_id: d.id,
+          defendant_name: "#{d.defendable.person.firstName} #{d.defendable.person.lastName}",
+          offence_id: offence.id,
+          offence_desc: offence.offenceTitle,
+          mode_of_trial: offence.modeOfTrial,
+          allocation_decision: offence.allocation_decision
+        }
+      end
+    end.flatten
+  end
 end

--- a/lib/tasks/demodata.rake
+++ b/lib/tasks/demodata.rake
@@ -38,15 +38,24 @@ def create_prosecution_cases
   puts " #{ICONS[:success]}"
 
   # create specific case with 3 random defendants plus Jammy Dodger
+  # - add allocation decisions to jammy dodger on offence
   print "[CREATE][PROSECUTION_CASE] #{CASE1[:URN]}"
   case1 = FactoryBot.create(
     :realistic_prosecution_case,
     prosecution_case_identifier: FactoryBot.create(:realistic_prosecution_case_identifier, caseURN: CASE1[:URN])
   )
   FactoryBot.create_list(:realistic_defendant, 2, prosecution_case: case1)
+  puts " #{ICONS[:success]}"
 
+  print "[CREATE][DEFENDANT] #{CASE1[:URN]}"
   person_defendant1 = FactoryBot.create(:realistic_person_defendant, person: person)
-  FactoryBot.create(:realistic_defendant, defendable: person_defendant1, prosecution_case: case1)
+  defendant1 = FactoryBot.create(:realistic_defendant, defendable: person_defendant1, prosecution_case: case1)
+  puts " #{ICONS[:success]}"
+
+  print "[CREATE][OFFENCE][ALLOCATION_DECISION] #{CASE1[:URN]}"
+  offence = defendant1.offences.first
+  offence.allocation_decision = FactoryBot.create(:realistic_allocation_decision)
+  offence.save!
   puts " #{ICONS[:success]}"
 
   # create specific case with 2 random defendants plus Jammy Dodger
@@ -60,6 +69,8 @@ def create_prosecution_cases
   person_defendant2 = FactoryBot.create(:realistic_person_defendant, person: person)
   FactoryBot.create(:realistic_defendant, defendable: person_defendant2, prosecution_case: case2)
   puts " #{ICONS[:success]}"
+
+  pp case_details_hash(CASE1[:URN])
 end
 
 def create_person

--- a/spec/tasks/demo_data_helper_spec.rb
+++ b/spec/tasks/demo_data_helper_spec.rb
@@ -98,4 +98,27 @@ RSpec.describe DemoDataHelper, type: :helper do
       it { is_expected.to eql('PAR54321') }
     end
   end
+
+  describe '#case_details_hash' do
+    subject(:results) { instance.case_details_hash(urn) }
+
+    let(:urn) { 'TESTURN123' }
+    let(:attributes) do
+      %i[defendant_id defendant_name offence_id offence_desc mode_of_trial allocation_decision]
+    end
+
+    before do
+      create(
+        :realistic_prosecution_case,
+        prosecution_case_identifier: create(:realistic_prosecution_case_identifier,
+                                            caseURN: urn)
+      )
+    end
+
+    it { is_expected.to be_an Array }
+
+    it { is_expected.to all(be_instance_of(Hash)) }
+
+    it { expect(results.map(&:keys)).to all(contain_exactly(*attributes)) }
+  end
 end

--- a/spec/tasks/demodata_spec.rb
+++ b/spec/tasks/demodata_spec.rb
@@ -15,27 +15,28 @@ RSpec.describe 'Demo data tasks', type: :rake do
   let(:unloader) { Rake::Task['mock:demodata:unload'].execute }
 
   context 'Demo data load' do
+    before { allow(FactoryBot).to receive(:create).and_call_original }
+
+    let(:person_attrs) do
+      {
+        title: 'MR',
+        firstName: 'Jammy',
+        middleName: '',
+        lastName: 'Dodger',
+        dateOfBirth: '21-MAY-1987'.to_date,
+        gender: 'MALE',
+        nationalInsuranceNumber: 'JC123456A'
+      }
+    end
+
     it 'creates 2 cases' do
       expect { loader }.to change(ProsecutionCase, :count).by(2)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'creates a specific person' do
-      allow(FactoryBot).to receive(:create)
-      expect(FactoryBot).to \
-        receive(:create).with(
-          :realistic_person,
-          title: 'MR',
-          firstName: 'Jammy',
-          middleName: '',
-          lastName: 'Dodger',
-          dateOfBirth: '21-MAY-1987'.to_date,
-          gender: 'MALE',
-          nationalInsuranceNumber: 'JC123456A'
-        )
+      expect(FactoryBot).to receive(:create).with(:realistic_person, person_attrs)
       loader
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   context 'Demo data unload' do


### PR DESCRIPTION
## What
Add allocation decisions to demo data example defendant

## Ticket

[CBO-1575 display allocation decisions](https://dsdmoj.atlassian.net/browse/CBO-1575)

## Why
The allocation decisions, and specifically
the motReasonDescription is important for
View court data - it impacts value of
fee claimable by providers.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.