### PR TITLE
add run yarn to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ EXPOSE 3000
 
 COPY . .
 
+RUN yarn install
 RUN SECRET_KEY_BASE=fake-key-base bundle exec rails assets:precompile
 
 # non-root/appuser should own only what they need to


### PR DESCRIPTION
Fix to allow docker to build 

Adding RUN yarn to Dockerfile to ensure webpacker is up to date for Docker build