### PR TITLE
Amend demo data to add sequential hearing days

### DIFF
--- a/lib/tasks/demodata.rake
+++ b/lib/tasks/demodata.rake
@@ -160,6 +160,7 @@ def create_cracked_ineffective_trial_for(prosecution_case:)
   raise "Hearing not found" unless prosecution_case.hearings.any?
 
   prosecution_case.hearings.last.tap do |hearing|
+    hearing.resulted = true
     hearing.cracked_ineffective_trial = FactoryBot.create(:realistic_cracked_ineffective_trial)
     hearing.save!
   end

--- a/lib/tasks/demodata.rake
+++ b/lib/tasks/demodata.rake
@@ -121,6 +121,8 @@ def create_hearings_for(prosecution_case:, defendant:)
   defence_counsels = FactoryBot.create_list(:defence_counsel, 2, defendant: defendant)
   puts " #{ICONS[:success]}"
 
+  base_date = "2019-10-23 00:00:00".to_datetime
+
   prosecution_case.hearings.each do |hearing|
     print "[CREATE][HEARINGS][DEFENCE_COUNSELS] for #{urn}"
     hearing.resulted = true
@@ -129,10 +131,14 @@ def create_hearings_for(prosecution_case:, defendant:)
     puts " #{ICONS[:success]}"
 
     print "[CREATE][HEARINGS][HEARING_DAYS] for #{urn}"
-    base_date = "2019-10-23 00:00:00".to_datetime
-    hearing.hearing_days << FactoryBot.create(:hearing_day, sittingDay: (base_date + 1.day + 8.hours + 30.minutes).to_s)
-    hearing.hearing_days << FactoryBot.create(:hearing_day, sittingDay: (base_date + 2.days + 10.hours + 45.minutes).to_s)
+    puts "base date for #{hearing.id} is #{base_date}"
+    hearing.hearing_days.destroy_all
+    hearing.hearing_days << FactoryBot.create(:hearing_day, sittingDay: (base_date + 0.days + 8.hours + 30.minutes).to_s)
+    hearing.hearing_days << FactoryBot.create(:hearing_day, sittingDay: (base_date + 1.day + 8.hours + 45.minutes).to_s)
+    hearing.hearing_days << FactoryBot.create(:hearing_day, sittingDay: (base_date + 2.days + 9.hours + 0.minutes).to_s)
+    base_date += 3.days
     hearing.save!
+
     puts " #{ICONS[:success]}"
 
     print "[CREATE][HEARINGS][HEARING_DAYS][HEARING_EVENT] for #{urn}"

--- a/spec/tasks/demodata_spec.rb
+++ b/spec/tasks/demodata_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe "Demo data tasks", type: :rake do
         expect(case1.hearings.map(&:hearing_days).map(&:size)).to eql([3, 3, 3])
       end
 
+      it "adds unique sequential sittingDays to hearing days" do
+        sitting_days = case1.hearings.flat_map { |h| h.hearing_days.map { |d| d.sittingDay.to_date } }
+        expected_dates = (0..8).map { |i| "2019-10-23".to_date + i.days }
+        expect(sitting_days).to contain_exactly(*expected_dates)
+      end
+
       it "adds 10 hearing events to each hearing day" do
         expect(case1.hearings.flat_map(&:hearing_days).map(&:events).map(&:size)).to eql(Array.new(9, 10))
       end


### PR DESCRIPTION
## What
Amend demo data to add sequential hearing days

## Why
This is needed to emulate more realistic
date ordering of hearings and their hearing_days
for the purposes of demoing pagination in VCD.

currently the demo data generated byt this task
creates hearings all with the same exact hearing
days (and time) - this is unrealistic.

## Ticket

VCD related [CBO-1417](https://dsdmoj.atlassian.net/browse/CBO-1417)

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.