### PR TITLE
Increase timeout for helm upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
           chart: ./helm_deploy/hmcts-common-platform-mock-api
           release-name: hmcts-common-platform-mock-api
           values-to-override: image.tag=$CIRCLE_SHA1
+          timeout: "600"
 
 workflows:
   version: 2


### PR DESCRIPTION
## What

We're currently getting this error on CircleCI at the `install_on_cluster` step:

```
helm upgrade --install hmcts-common-platform-mock-api ./helm_deploy/hmcts-common-platform-mock-api "$@"
Error: UPGRADE FAILED: timed out waiting for the condition
```

This PR doubles the timeout from the default 300s (5 mins).

If this doesn't fix the issue, we will have to investigate further.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
