### PR TITLE
Fix JudicialResult migration

### DIFF
--- a/db/migrate/20210128160503_add_judicial_result_offence_relationship.rb
+++ b/db/migrate/20210128160503_add_judicial_result_offence_relationship.rb
@@ -1,10 +1,6 @@
 class AddJudicialResultOffenceRelationship < ActiveRecord::Migration[6.0]
-  def change
-    reversible do |dir|
-      dir.up do
-        execute "DELETE FROM judicial_results;"
-      end
-    end
+  def up
+    JudicialResult.delete_all
 
     add_reference :judicial_results, :hearing, type: :uuid, null: false, foreign_key: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_143221) do
+ActiveRecord::Schema.define(version: 2021_01_28_160503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -505,6 +505,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_143221) do
 
   create_table "judicial_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "judicialResultId"
+    t.uuid "orderedHearingId"
     t.string "label"
     t.string "welshLabel"
     t.boolean "isAdjournmentResult", null: false
@@ -536,7 +537,6 @@ ActiveRecord::Schema.define(version: 2021_02_05_143221) do
     t.uuid "defendant_id"
     t.uuid "court_application_id"
     t.uuid "judicialResultTypeId"
-    t.uuid "orderedHearingId"
     t.uuid "hearing_id", null: false
     t.index ["court_application_id"], name: "index_judicial_results_on_court_application_id"
     t.index ["court_clerk_id"], name: "index_judicial_results_on_court_clerk_id"
@@ -659,14 +659,6 @@ ActiveRecord::Schema.define(version: 2021_02_05_143221) do
 
   create_table "merged_prosecution_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "prosecutionCaseReference"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "mode_of_trial_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "seq_number"
-    t.integer "reason_code"
-    t.string "reason_description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
We cannot delete JudicialResults before deleting their dependent
JuidicalResultPrompts.

We use ActiveRecord's .delete_all in order to benefit from the
`dependent: :destroy` that we specified on the `JudicialResult`
model.

This is causing the deployment to fail on master.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASBXXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
