### PR TITLE
Use destroy_all instead of delete_all to trigger dependent destroy callback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,6 @@ jobs:
           chart: ./helm_deploy/hmcts-common-platform-mock-api
           release-name: hmcts-common-platform-mock-api
           values-to-override: image.tag=$CIRCLE_SHA1
-          wait: false
 
 workflows:
   version: 2

--- a/db/migrate/20210128160503_add_judicial_result_hearing_relationship.rb
+++ b/db/migrate/20210128160503_add_judicial_result_hearing_relationship.rb
@@ -1,0 +1,7 @@
+class AddJudicialResultHearingRelationship < ActiveRecord::Migration[6.0]
+
+  def up
+    JudicialResult.destroy_all
+    add_reference :judicial_results, :hearing, type: :uuid, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20210128160503_add_judicial_result_offence_relationship.rb
+++ b/db/migrate/20210128160503_add_judicial_result_offence_relationship.rb
@@ -1,7 +1,0 @@
-class AddJudicialResultOffenceRelationship < ActiveRecord::Migration[6.0]
-  def up
-    JudicialResult.delete_all
-
-    add_reference :judicial_results, :hearing, type: :uuid, null: false, foreign_key: true
-  end
-end


### PR DESCRIPTION
## What

* Use `destroy_all` instead of `delete_all` to trigger dependent destroy callback
* Remove wait flag for `helm-upgrade`

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
