### PR TITLE
CRUD for judicial results + create next hearing

### DIFF
--- a/app/controllers/admin/judicial_results_controller.rb
+++ b/app/controllers/admin/judicial_results_controller.rb
@@ -3,9 +3,87 @@ module Admin
     def create
       offence = Offence.find(params[:offence_id])
       hearing = Hearing.find(params[:id])
-      FactoryBot.create(:judicial_result, hearing: hearing, offence: offence)
+      FactoryBot.create(:judicial_result_with_relationships, hearing: hearing, offence: offence)
 
-      redirect_to edit_admin_hearing_url(hearing)
+      redirect_to edit_admin_hearing_url(hearing), notice: "Judicial result was successfully created."
+    end
+
+    def show
+      @hearing = Hearing.find(params[:id])
+      @offence = Offence.find(params[:offence_id])
+      @judicial_result = JudicialResult.find(params[:judicial_result_id])
+    end
+
+    def edit
+      @hearing = Hearing.find(params[:id])
+      @offence = Offence.find(params[:offence_id])
+      @judicial_result = JudicialResult.find(params[:judicial_result_id])
+    end
+
+    def update
+      @hearing = Hearing.find(params[:id])
+      @offence = Offence.find(params[:offence_id])
+      @judicial_result = JudicialResult.find(params[:judicial_result_id])
+
+      if @judicial_result.update(judicial_result_params)
+        render :show, notice: "Judicial result was successfully updated."
+      else
+        render :edit
+      end
+    end
+
+    def delete
+      @hearing = Hearing.find(params[:id])
+      JudicialResult.find(params[:judicial_result_id]).destroy!
+      redirect_to admin_hearing_url(@hearing), notice: "Judicial result was successfully deleted."
+    end
+
+  private
+
+    def judicial_result_params
+      params.require(:judicial_result).permit(judicial_result_attributes)
+    end
+
+    def judicial_result_attributes
+      [
+        :id,
+        :judicialResultId,
+        :judicialResultTypeId,
+        :orderedHearingId,
+        :label,
+        :welshLabel,
+        :isAdjournmentResult,
+        :isFinancialResult,
+        :isConvictedResult,
+        :isAvailableForCourtExtract,
+        :isDeleted,
+        :amendmentReasonId,
+        :amendmentReason,
+        :amendmentDate,
+        :qualifier,
+        :resultText,
+        :cjsCode,
+        :rank,
+        :orderedDate,
+        :postHearingCustodyStatus,
+        :lastSharedDateTime,
+        :terminatesOffenceProceedings,
+        :approvedDate,
+        :category,
+        next_hearing_attributes: next_hearing_attributes,
+      ]
+    end
+
+    def next_hearing_attributes
+      [
+        :id,
+        :listedStartDateTime,
+        :jurisdictionType,
+        :estimatedMinutes,
+        :hearingLanguage,
+        :court_centre_id,
+        hearing_type_attributes: %i[id description],
+      ]
     end
   end
 end

--- a/app/models/judicial_result.rb
+++ b/app/models/judicial_result.rb
@@ -5,6 +5,7 @@ class JudicialResult < ApplicationRecord
 
   POST_HEARING_CUSTODY_STATUSES = %w[A B C L P R S U].freeze
   CATEGORIES = %w[FINAL INTERMEDIARY ANCILLARY].freeze
+
   belongs_to :court_clerk, class_name: "DelegatedPowers", optional: true
   belongs_to :delegated_powers, optional: true
   belongs_to :four_eyes_approval, class_name: "DelegatedPowers", optional: true
@@ -25,6 +26,8 @@ class JudicialResult < ApplicationRecord
   validates :resultText, presence: true
   validates :terminatesOffenceProceedings, inclusion: [true, false]
   validates :postHearingCustodyStatus, inclusion: POST_HEARING_CUSTODY_STATUSES, allow_blank: true
+
+  accepts_nested_attributes_for :next_hearing, reject_if: :all_blank, allow_destroy: true
 
   def to_builder
     Jbuilder.new do |judicial_result|

--- a/app/models/next_hearing.rb
+++ b/app/models/next_hearing.rb
@@ -16,6 +16,8 @@ class NextHearing < ApplicationRecord
   validates :jurisdictionType, inclusion: %w[MAGISTRATES CROWN]
   validates :hearingLanguage, inclusion: %w[ENGLISH WELSH]
 
+  accepts_nested_attributes_for :hearing_type, reject_if: :all_blank
+
   def to_builder
     Jbuilder.new do |next_hearing|
       next_hearing.type hearing_type.to_builder

--- a/app/views/admin/hearings/_add_judicial_result.html.erb
+++ b/app/views/admin/hearings/_add_judicial_result.html.erb
@@ -1,6 +1,0 @@
-<%= fields_for @offence do |offence_form| %>
-    <%= offence_form.fields_for :judicial_results do |judicial_result_form| %>
-      <%= render 'judicial_result_fields', f: judicial_result_form %>
-    <% end %>
-  <% end %>
-  

--- a/app/views/admin/hearings/_form.html.erb
+++ b/app/views/admin/hearings/_form.html.erb
@@ -110,7 +110,7 @@
 
           <div>
             <%= offence.fields_for :judicial_results do |judicial_result| %>
-              <%= render 'judicial_result_fields', f: judicial_result %>
+              <%= render 'admin/judicial_results/form', f: judicial_result %>
             <% end %>
 
             <% if offence.object.judicial_results.empty? %>

--- a/app/views/admin/hearings/show.html.erb
+++ b/app/views/admin/hearings/show.html.erb
@@ -1,44 +1,53 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Hearing <%= @hearing.id %> </h1>
+<h1>Hearing</h1>
 
-<h2>Location</h2>
-<li><%= @hearing.court_centre.name %></li>
+<p>ID: <%= @hearing.id %></p>
+<p>Location: <%= @hearing.court_centre.name %></p>
 
 <h2>Days</h2>
+
 <ol>
-<% @hearing.hearing_days.each do |hearing_day| %>
-  <li><%= hearing_day.sittingDay.to_date %></li>
-<% end %>
+  <% @hearing.hearing_days.each do |hearing_day| %>
+    <li><%= hearing_day.sittingDay.to_date %></li>
+  <% end %>
 </ol>
 
 <h2>Defendants</h2>
 
 <% @hearing.defendants.each do |defendant| %>
-
   <ul>
-    <li><%= defendant.name %></li>
+    <li>Name: <%= defendant.name %></li>
   </ul>
 
+  <h3>Offences</h3>
+
   <% defendant.offences.each do |offence| %>
-      <h3>Offences</h3>
+
       <ul>
-        <li><%= offence.offenceTitle %></li>
+        <li>
+          <%= offence.offenceTitle %>
+
+          <p>Judicial results:</p>
+          <ul>
+            <% offence.judicial_results.each do |judicial_result| %>
+              <li>Text: <%= link_to judicial_result.resultText, judicial_result_admin_hearing_path(@hearing, offence, judicial_result) %></li>
+              <p>Next hearing: <%= judicial_result.next_hearing.listedStartDateTime %> (estimated length: <%= judicial_result.next_hearing.estimatedMinutes %> minutes)</p>
+            <% end %>
+          </ul>
+
+          <p>Pleas:</p>
+          <ul>
+            <% offence.pleas.each do |plea| %>
+              <li><%= plea.pleaValue %></li>
+            <% end %>
+          </ul>
+        </li>
       </ul>
-      
-      <h4>Plea</h4>
-      <% offence.pleas.each do |plea| %>
-        <%= plea.pleaValue %>
-      <% end %>
-
-      <h4>Judicial Result</h4>
-      <% offence.judicial_results.each do |judicial_result| %>
-        <%= judicial_result %>
-      <% end %>
-
     <% end %>
 <% end %>
 
+<hr />
 
 <%= link_to 'Edit', edit_admin_hearing_path(@hearing) %> |
 <%= link_to 'Back', admin_prosecution_case_path(@prosecution_case) %>

--- a/app/views/admin/judicial_results/_form.html.erb
+++ b/app/views/admin/judicial_results/_form.html.erb
@@ -4,90 +4,145 @@
     <%= f.label :judicialResultId, 'Judicial Result Id' %>
     <%= f.text_field :judicialResultId %>
   </div>
+
   <div class="field">
     <%= f.label :judicialResultTypeId, 'Judicial Result Type Id' %>
     <%= f.text_field :judicialResultTypeId %>
   </div>
+
   <div class="field">
     <%= f.label :label, 'Label'%>
     <%= f.text_field :label %>
   </div>
+
   <div class="field">
     <%= f.label :welshLabel, 'Welsh Label' %>
     <%= f.text_field :welshLabel %>
   </div>
+
   <div class="field">
     <%= f.label :isAdjournmentResult, 'Is Adjournment Result' %>
     <%= f.check_box :isAdjournmentResult %>
   </div>
+
   <div class="field">
     <%= f.label :isFinancialResult, 'Is Financial Result' %>
     <%= f.check_box :isFinancialResult %>
   </div>
+
   <div class="field">
     <%= f.label :isConvictedResult, 'Is Convicted Result' %>
     <%= f.check_box :isConvictedResult %>
   </div>
+
   <div class="field">
     <%= f.label :isAvailableForCourtExtract, 'Is Available For Court Extract' %>
     <%= f.check_box :isAvailableForCourtExtract %>
   </div>
+
   <div class="field">
     <%= f.label :isDeleted, 'Is Deleted' %>
     <%= f.check_box :isDeleted %>
   </div>
+
   <div class="field">
     <%= f.label :amendmentReasonId, 'Amendment Reason Id' %>
     <%= f.text_field :amendmentReasonId %>
   </div>
+
   <div class="field">
     <%= f.label :amendmentReason, 'Amendment Reason Id' %>
     <%= f.text_field :amendmentReason %>
   </div>
+
   <div class="field">
     <%= f.label :amendmentDate, 'Amendment Date' %>
     <%= f.text_field :amendmentDate %>
   </div>
+
   <div class="field">
     <%= f.label :qualifier, 'Qualifier' %>
     <%= f.text_field :qualifier %>
   </div>
+
   <div class="field">
     <%= f.label :resultText, 'Result Text' %>
     <%= f.text_field :resultText %>
   </div>
+
   <div class="field">
     <%= f.label :cjsCode, 'CJS Code' %>
     <%= f.text_field :cjsCode %>
   </div>
+  
   <div class="field">
     <%= f.label :rank, 'Rank' %>
     <%= f.text_field :rank %>
   </div>
+
   <div class="field">
     <%= f.label :orderedDate, 'Ordered Date' %>
     <%= f.text_field :orderedDate %>
   </div>
+
   <div class="field">
     <%= f.label :postHearingCustodyStatus, 'Post Hearing Custody Status' %>
     <%= f.select :postHearingCustodyStatus, JudicialResult::POST_HEARING_CUSTODY_STATUSES, include_blank: true %>
   </div>
+
   <div class="field">
     <%= f.label :lastSharedDateTime, 'Last Shared Date Time' %>
     <%= f.text_field :lastSharedDateTime %>
   </div>
+
   <div class="field">
     <%= f.label :terminatesOffenceProceedings, 'Terminates Offence Proceedings' %>
     <%= f.check_box :terminatesOffenceProceedings %>
   </div>
+
   <div class="field">
     <%= f.label :approvedDate, 'Approved Date' %>
     <%= f.text_field :approvedDate %>
   </div>
+
   <div class="field">
     <%= f.label :category, 'Category' %>
     <%= f.select :category, JudicialResult::CATEGORIES %>
   </div>
 
-  <%= link_to_remove_association "remove judicial result", f %>
+  <h3>Next Hearing</h3>
+
+  <%= f.fields_for :next_hearing do |next_hearing| %>
+    <div class="field">
+      <%= next_hearing.label :listedStartDateTime %>
+      <%= next_hearing.text_field :listedStartDateTime %>
+    </div>
+
+    <div class="field">
+      <%= next_hearing.label :jurisdictionType %>
+      <%= next_hearing.text_field :jurisdictionType %>
+    </div>
+
+    <div class="field">
+      <%= next_hearing.label :estimatedMinutes %>
+      <%= next_hearing.text_field :estimatedMinutes %>
+    </div>
+
+    <div class="field">
+      <%= next_hearing.label :hearingLanguage %>
+      <%= next_hearing.text_field :hearingLanguage %>
+    </div>
+
+    <div class="field">
+      <%= next_hearing.label :court_centre_id, 'Court Centre' %>
+      <%= next_hearing.select :court_centre_id, HmctsCommonPlatform::Reference::CourtCentre.all.collect{ |cc| [cc.oucode_l3_name, cc.id ] } %>
+    </div>
+
+    <%= next_hearing.fields_for :hearing_type do |hearing_type| %>
+      <div class="field">
+        <%= hearing_type.label :description, 'Hearing Type description' %>
+        <%= hearing_type.text_field :description %>
+      </div>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/admin/judicial_results/edit.html.erb
+++ b/app/views/admin/judicial_results/edit.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: @judicial_result, local: true, url: judicial_result_admin_hearing_path) do |form| %>
+  <%= render 'form', f: form %>
+  <%= form.submit %>
+<% end %>

--- a/app/views/admin/judicial_results/show.html.erb
+++ b/app/views/admin/judicial_results/show.html.erb
@@ -1,0 +1,18 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Judicial Result</h1>
+
+<% @judicial_result.attributes.each do |key, value| %>
+  <p><strong><%= key %></strong>: <%= value %></p>
+<% end %>
+
+<h2>Next hearing</h2>
+
+<% @judicial_result.next_hearing.attributes.each do |key, value| %>
+  <p><strong><%= key %></strong>: <%= value %></p>
+<% end %>
+
+<hr />
+
+<p><%= link_to "Edit judicial result", edit_judicial_result_admin_hearing_path(@hearing, @offence, @judicial_result) %></p>
+<p><%= link_to "Delete judicial result", delete_judicial_result_admin_hearing_path(@hearing, @offence, @judicial_result), method: "DELETE" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,17 @@ Rails.application.routes.draw do
         member do
           post "offences/:offence_id/pleas" => "pleas#create", as: :add_plea
           post "offences/:offence_id/allocation_decisions" => "allocation_decisions#create", as: :add_allocation_decision
+
           post "offences/:offence_id/judicial_results" => "judicial_results#create", as: :add_judicial_result
+          get "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#show", as: :judicial_result
+          get "offences/:offence_id/judicial_results/:judicial_result_id/edit" => "judicial_results#edit", as: :edit_judicial_result
+          put "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#update", as: :update_judicial_result
+          delete "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#delete", as: :delete_judicial_result
         end
       end
     end
   end
+
   resources :status, only: [:index]
 
   resources :prosecution_cases, path: "/prosecutionCases", only: [:index]

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
 
     association :defence_organisation, factory: :realistic_associated_defence_organisation, defendant: nil
     after(:build) do |defendant|
-      defendant.offences << build(:realistic_offence, defendant: nil)
+      defendant.offences << build(:offence_with_relationships, defendant: nil)
       defendant.associated_people << build_list(:realistic_associated_person,
                                                 Faker::Number.between(from: 0, to: 3))
       defendant.defendant_aliases << build_list(:realistic_defendant_alias,

--- a/spec/factories/offences.rb
+++ b/spec/factories/offences.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
       association :offence_facts, factory: :offence_facts
       after(:build) do |offence|
         offence.victims << build(:person_with_relationships)
+        offence.judicial_results << build(:judicial_result_with_relationships)
       end
 
       factory :offence_with_relationships_and_laa_reference do

--- a/spec/requests/admin/judicial_results_spec.rb
+++ b/spec/requests/admin/judicial_results_spec.rb
@@ -5,23 +5,67 @@ require "rails_helper"
 RSpec.describe "/admin/hearings/:hearing_id/offences/:offence_id/judicial_results", type: :request do
   let(:hearing) { FactoryBot.create(:hearing, :with_prosecution_case) }
   let(:prosecution_case) { hearing.prosecution_cases.first }
+  let(:offence) { prosecution_case.defendants.first.offences.first }
+
   let(:headers) { { 'Authorization': authorisation } }
   let(:authorisation) { ActionController::HttpAuthentication::Basic.encode_credentials(ENV["ADMIN_USERNAME"], ENV["ADMIN_PASSWORD"]) }
 
-  describe "POST /create" do
-    let(:offence) { prosecution_case.defendants.first.offences.first }
-
-    context "with valid parameters" do
-      it "creates a new Hearing" do
-        expect {
-          post add_judicial_result_admin_hearing_url(hearing, offence), headers: headers
-        }.to change(offence.judicial_results, :count).by(1)
-      end
-
-      it "redirects to the prosecution case" do
+  describe "POST /judicial_results" do
+    it "creates a new Hearing" do
+      expect {
         post add_judicial_result_admin_hearing_url(hearing, offence), headers: headers
-        expect(response).to redirect_to(edit_admin_hearing_url(hearing))
-      end
+      }.to change(offence.judicial_results, :count).by(1)
+    end
+
+    it "creates a new judicial result with a next hearing" do
+      expect {
+        post add_judicial_result_admin_hearing_url(hearing, offence), headers: headers
+      }.to change(NextHearing, :count).by(1)
+    end
+
+    it "redirects to the prosecution case" do
+      post add_judicial_result_admin_hearing_url(hearing, offence), headers: headers
+      expect(response).to redirect_to(edit_admin_hearing_url(hearing))
+    end
+  end
+
+  describe "GET /judicial_result" do
+    it "shows a judicial result page" do
+      judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
+      get judicial_result_admin_hearing_path(hearing, offence, judicial_result), headers: headers
+      expect(response).to be_ok
+    end
+  end
+
+  describe "GET /judicial_result/id/edit" do
+    it "shows the judicial result edit page" do
+      judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
+      get edit_judicial_result_admin_hearing_path(hearing, offence, judicial_result), headers: headers
+      expect(response).to be_ok
+    end
+  end
+
+  describe "PUT /judicial_result/id" do
+    it "updates a judicial result" do
+      judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
+      put update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: "foo" } }, headers: headers
+      expect(judicial_result.reload.label).to eql("foo")
+    end
+
+    it "renders edit page when update fails" do
+      judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
+      put update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: nil } }, headers: headers
+      expect(response).to be_ok
+    end
+  end
+
+  describe "DELETE /judicial_result/id" do
+    it "deletes a judicial result" do
+      judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
+      expect(offence.judicial_results.count).to be(1)
+
+      delete delete_judicial_result_admin_hearing_path(hearing, offence, judicial_result), headers: headers
+      expect(offence.judicial_results.count).to be(0)
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-516)

As an HMCTS mock admin user, I want Date of Next Hearing to be populated.

This was started in https://github.com/ministryofjustice/hmcts-common-platform-mock-api/pull/377, but due to major code conflicts, it was just easier to do it again here.

## Why

In the current form of the mock, the Date of Next Hearing is not populated

## DoD

Date of Next Hearing updated when new offence created using the admin mock tool.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
