### PR TITLE
Use HTTP verb PATCH instead of PUT

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
           post "offences/:offence_id/judicial_results" => "judicial_results#create", as: :add_judicial_result
           get "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#show", as: :judicial_result
           get "offences/:offence_id/judicial_results/:judicial_result_id/edit" => "judicial_results#edit", as: :edit_judicial_result
-          put "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#update", as: :update_judicial_result
+          patch "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#update", as: :update_judicial_result
           delete "offences/:offence_id/judicial_results/:judicial_result_id" => "judicial_results#delete", as: :delete_judicial_result
         end
       end

--- a/spec/requests/admin/judicial_results_spec.rb
+++ b/spec/requests/admin/judicial_results_spec.rb
@@ -45,16 +45,16 @@ RSpec.describe "/admin/hearings/:hearing_id/offences/:offence_id/judicial_result
     end
   end
 
-  describe "PUT /judicial_result/id" do
+  describe "PATCH /judicial_result/id" do
     it "updates a judicial result" do
       judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
-      put update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: "foo" } }, headers: headers
+      patch update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: "foo" } }, headers: headers
       expect(judicial_result.reload.label).to eql("foo")
     end
 
     it "renders edit page when update fails" do
       judicial_result = FactoryBot.create(:judicial_result_with_relationships, offence: offence)
-      put update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: nil } }, headers: headers
+      patch update_judicial_result_admin_hearing_path(hearing, offence, judicial_result), params: { judicial_result: { label: nil } }, headers: headers
       expect(response).to be_ok
     end
   end


### PR DESCRIPTION
The verb used by the app is `PATCH` rather than `PUT`, so the user was unable to update a judicial result.
