### PR TITLE
Deny read permission to group and others on ~/.kube/config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,9 @@ jobs:
       - kubernetes/install-kubectl
       - helm/install-helm-client:
           version: 'v3.5.4'
+      - run:
+          name: deny read-permission to group and others for ~/.kube/config
+          command: chmod go-r ~/.kube/config
       - helm/upgrade-helm-chart:
           namespace: hmcts-mock-api-dev
           update-repositories: false


### PR DESCRIPTION
Fixes:

```
WARNING: Kubernetes configuration file is group-readable.

This is insecure. Location: /home/circleci/.kube/config

Error: UPGRADE FAILED: timed out waiting for the condition
```
