### PR TITLE
Revert to exposing defendant first, middle and last names

### DIFF
--- a/app/models/defendant_summary.rb
+++ b/app/models/defendant_summary.rb
@@ -17,7 +17,9 @@ class DefendantSummary
       if defendant.person?
         defendant_summary.defendantNINO defendant.defendable.person.nationalInsuranceNumber
         defendant_summary.defendantASN defendant.defendable.arrestSummonsNumber
-        defendant_summary.defendantName defendant_person_name
+        defendant_summary.defendantFirstName defendant_first_name
+        defendant_summary.defendantMiddleName defendant_middle_name
+        defendant_summary.defendantLastName defendant_last_name
         defendant_summary.defendantDOB defendant.defendable.person.dateOfBirth.to_date
       else
         defendant_summary.defendantName defendant_organisation_name
@@ -43,16 +45,16 @@ private
     defendant.defendable.person.first_name
   end
 
+  def defendant_middle_name
+    defendant.defendable.person.middle_name
+  end
+
   def defendant_last_name
     defendant.defendable.person.last_name
   end
 
   def defendant_organisation_name
     defendant.defendable.organisation.name
-  end
-
-  def defendant_person_name
-    defendant_first_name + defendant_last_name
   end
 
   def offences_builder

--- a/lib/schemas/global/search/apiDefendantSummary.json
+++ b/lib/schemas/global/search/apiDefendantSummary.json
@@ -20,6 +20,18 @@
           "description": "The name of the defendant",
           "type": "string"
         },
+        "defendantFirstName": {
+          "description": "The first name of the defendant",
+          "type": "string"
+        },
+        "defendantMiddleName": {
+          "description": "The middle name of the defendant",
+          "type": "string"
+        },
+        "defendantLastName": {
+          "description": "The last name of the defendant",
+          "type": "string"
+        },
         "defendantDOB": {
           "description": "The person date of birth when the defendant is a person",
           "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/datePattern"
@@ -41,10 +53,23 @@
             }
         }
     },
-    "required": [
-        "defendantId",
-        "defendantName",
-        "offenceSummary"
+    "oneOf": [
+       {
+            "required": [
+              "defendantId",
+              "defendantName",
+              "offenceSummary"
+           ]
+       },
+       {
+            "required": [
+              "defendantId",
+              "defendantFirstName",
+              "defendantMiddleName",
+              "defendantLastName",
+              "offenceSummary"
+            ]
+       }
     ],
     "additionalProperties": false
 }


### PR DESCRIPTION
## What

The new HMCTS Common Platform schema removed `defendantFirstName`, `defendantLastName`, and `defendantMiddleName` in favour of just `defendantName`. This breaks VCD, and would break MLRA too, so we're going to push back on this schema change.

This PR reverts back to using `defendantFirstName`, `defendantLastName`, and `defendantMiddleName` on `defendantSummary`.