### PR TITLE
Silence the PgSearch deprecation warning

### DIFF
--- a/app/models/prosecution_case.rb
+++ b/app/models/prosecution_case.rb
@@ -11,7 +11,7 @@ class ProsecutionCase < ApplicationRecord
   has_many :prosecution_case_hearings, dependent: :destroy
   has_many :hearings, through: :prosecution_case_hearings, inverse_of: :prosecution_cases
 
-  include PgSearch
+  include PgSearch::Model
   pg_search_scope :search,
                   associated_against: { prosecution_case_identifier: :caseURN },
                   using: {


### PR DESCRIPTION
> DEPRECATION WARNING: Directly including `PgSearch` into an Active Record model is deprecated and will be removed in pg_search 3.0.