### PR TITLE
add offence fields to defendant form

### DIFF
--- a/app/controllers/admin/defendants_controller.rb
+++ b/app/controllers/admin/defendants_controller.rb
@@ -18,7 +18,7 @@ module Admin
       @defendant = @prosecution_case.defendants.build(defendant_params)
 
       if @defendant.save
-        redirect_to [:admin, @defendant], notice: "Defendant was successfully created."
+        redirect_to [:admin, @prosecution_case], notice: "Defendant was successfully created."
       else
         render :new
       end

--- a/app/views/admin/defendants/_defendant.html.erb
+++ b/app/views/admin/defendants/_defendant.html.erb
@@ -50,7 +50,7 @@
 
 <hr>
 
-<h3> Defendable</h3>
+<h3>Defendable</h3>
 
 <%= defendant.hidden_field :defendable_type %>
 
@@ -198,4 +198,10 @@
       <%= person.text_field :specificRequirements %>
     </div>
   <% end %>
+<% end %>
+
+<h3>Offences</h3>
+
+<%= defendant.fields_for :offences do |offence| %>
+  <%= render 'admin/offences/fields', offence: offence %>
 <% end %>

--- a/spec/requests/admin/defendants_request_spec.rb
+++ b/spec/requests/admin/defendants_request_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe "Admin::Defendants", type: :request do
         }.to change(Defendant, :count).by(1)
       end
 
-      it "redirects to the created defendant" do
+      it "redirects to parent prosecution case" do
         post admin_prosecution_case_defendants_url(prosecution_case), params: { defendant: valid_attributes }, headers: headers
-        expect(response).to redirect_to(admin_defendant_url(Defendant.order(created_at: :asc).last))
+        expect(response).to redirect_to(admin_prosecution_case_url(Defendant.order(created_at: :asc).last.prosecution_case))
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/-LASB696)

Added offence fields to defendant form, to allow for the creation of a new defendant (currently prevented by form validation errors due to missing offence)

Changed redirect on submit to return to prosecution case show view to be consistent with creating a new hearing. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
