### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+* @ministryofjustice/laa-crime-apps-ruby-devs


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

This PR sets the `@ministryofjustice/laa-crime-apps-ruby-devs` team as codeowner.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners