### PR TITLE
Bump Ubuntu to 20.04 to fix Brakeman Github Action

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Brakeman


### PR DESCRIPTION
The ubuntu-18.04 environment is deprecated and causes Github Actions to fail the brakeman workflow.

This bumps Ubuntu to 20.04 to fix Brakeman Github Action.

Fixes errors: https://github.com/ministryofjustice/laa-court-data-adaptor/actions/runs/2904906832