### PR TITLE
set version on brakeman to use when running the linter action.

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
+    - name: Install gems
+      run: |
+        gem install brakeman -v 5.4.1
     - name: Brakeman
       uses: devmasx/brakeman-linter-action@v1.0.0
       env:

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -4,13 +4,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install gems
-      run: |
-        gem install brakeman -v 5.4.1
-    - name: Brakeman
-      uses: devmasx/brakeman-linter-action@v1.0.0
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+    - run: gem install brakeman --version 5.4.1
+    - run: brakeman
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## What

- [x] brakeman version for the linter action set to 5.4.1 until Ruby version is updated.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and linters should be passing
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
