### PR TITLE
ACD-255: Add defenceCounsel to hearing summary

### DIFF
--- a/app/models/hearing_summary.rb
+++ b/app/models/hearing_summary.rb
@@ -19,6 +19,7 @@ class HearingSummary
       hearing_summary.hearingType hearing.hearing_type.to_builder
       hearing_summary.defendantIds defendants_builder
       hearing_summary.hearingDays hearing_days_builder
+      hearing_summary.defenceCounsel hearing.defence_counsels.map(&:to_builder)
     end
   end
 


### PR DESCRIPTION
## What
ACD-255 is a bug that only appears in hearing summary payloads containing defence counsels, but the mock API never returns defence counsels in the payload, so this addresses that.

(Note there's already a spec validating the payload which would fail if the below contravened the spec)

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-255)
