### PR TITLE
Tweak how hearings and logs are found

### DIFF
--- a/app/services/hearing_finder.rb
+++ b/app/services/hearing_finder.rb
@@ -12,7 +12,7 @@ class HearingFinder < ApplicationService
     raise Errors::InvalidParams, errors if errors.present?
 
     if params[:sittingDay]
-      Hearing.find_by(hearing_id: params[:hearingId], sitting_day: params[:sittingDay], resulted: true)
+      Hearing.where("sitting_day::date = ?", params[:sittingDay]).find_by(hearing_id: params[:hearingId], resulted: true)
     else
       Hearing.where(hearing_id: params[:hearingId], resulted: true).order("sitting_day").last
     end

--- a/app/services/hearing_log_finder.rb
+++ b/app/services/hearing_log_finder.rb
@@ -19,11 +19,15 @@ private
   attr_reader :params, :schema
 
   def hearing_day
-    HearingDay.find_by!(sittingDay: params[:date].to_date.all_day, hearing_id: params[:hearingId])
+    HearingDay.find_by!(sittingDay: params[:date].to_date.all_day, hearing_id: internal_hearing_id)
   end
 
   def permitted_params
     params.permit(:hearingId, :date)
+  end
+
+  def internal_hearing_id
+    Hearing.find_by!(hearing_id: params[:hearingId]).id
   end
 
   def register_dependant_schemas!

--- a/spec/requests/hearing_logs_spec.rb
+++ b/spec/requests/hearing_logs_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "HearingLogs", type: :request do
 
   describe "GET /hearing/hearingLog" do
     let(:hearing_day) { hearing.hearing_days.first }
-    let(:params) { { hearingId: hearing.id, date: hearing_day.sittingDay.strftime("%Y-%m-%d") } }
+    let(:params) { { hearingId: hearing.hearing_id, date: hearing_day.sittingDay.strftime("%Y-%m-%d") } }
 
     before { FactoryBot.create(:hearing_event, hearing_day:) }
 

--- a/spec/services/hearing_log_finder_spec.rb
+++ b/spec/services/hearing_log_finder_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HearingLogFinder do
     let(:hearing_event) { FactoryBot.create(:hearing_event, hearing_day: hearing.hearing_days.first) }
 
     let(:params_hash) do
-      { hearingId: hearing.id, date: "2019-10-23" }
+      { hearingId: hearing.hearing_id, date: "2019-10-23" }
     end
 
     it { is_expected.to eq([hearing_event]) }


### PR DESCRIPTION
## What

`Hearing#sitting_day` is a datetime in the DB, whereas the `sittingDay` param is a date string, so this was always failing on lookup because "2025-03-21 11:11:11.111" does not match "2025-03-21 00:00:00.000".

Also, `HearingLogFinder` was looking up `HearingDay`s by checking their `hearing_id` compared to `params[:hearingId]`. But `HearingDay.hearing_id` corresponds to `Hearing.id`, whereas `params[:hearingId]` corresponds to `Hearing.hearing_id`