### PR TITLE
ACD-586: Add rep order endpoint

### DIFF
--- a/app/models/court_application_defendant_summary.rb
+++ b/app/models/court_application_defendant_summary.rb
@@ -27,7 +27,7 @@ class CourtApplicationDefendantSummary
       defendant_summary.proceedingsConcluded proceedings_concluded?
       defendant_summary.masterDefendantId defendant.masterDefendantId
       defendant_summary.subjectId defendant_id
-      defendant_summary.offenceSummary defendant.offences
+      defendant_summary.offenceSummary offence_summary
     end
   end
 
@@ -55,5 +55,9 @@ private
 
   def defendant_organisation_name
     defendant.defendable.organisation.name
+  end
+
+  def offence_summary
+    defendant.offences.map { |offence| offence.to_builder.attributes! }
   end
 end

--- a/app/services/laa_representation_order_recorder.rb
+++ b/app/services/laa_representation_order_recorder.rb
@@ -13,7 +13,7 @@ class LaaRepresentationOrderRecorder < ApplicationService
 
     offence = Offence.find(params[:offenceId])
 
-    defendant = Defendant.find(params[:defendantId])
+    defendant = offence.defendant
 
     offence.build_laa_reference if offence.laa_reference.blank?
     defendant.build_defence_organisation if defendant.defence_organisation.blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
     "/defendants/:defendantId" \
     "/offences/:offenceId" => "representation_orders#create", as: :representation_order
   post "/prosecutionCases/representationOrder" \
-    "/application/:applicationId" \
+    "/applications/:applicationId" \
     "/subject/:subjectId" \
     "/offences/:offenceId" => "representation_orders#create"
   get "/hearing/results" => "hearings#show", as: :hearing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,10 @@ Rails.application.routes.draw do
     "/cases/:prosecutionCaseId" \
     "/defendants/:defendantId" \
     "/offences/:offenceId" => "representation_orders#create", as: :representation_order
+  post "/prosecutionCases/representationOrder" \
+    "/application/:applicationId" \
+    "/subject/:subjectId" \
+    "/offences/:offenceId" => "representation_orders#create"
   get "/hearing/results" => "hearings#show", as: :hearing
   get "/hearing/hearingLog" => "hearing_logs#show", as: :hearing_log
   get "/applications/:applicationId" => "court_application#index", as: :applications

--- a/lib/schemas/api/progression.recordRepresentationOrder.json
+++ b/lib/schemas/api/progression.recordRepresentationOrder.json
@@ -8,8 +8,16 @@
             "description": "The identifier of the prosecution case",
             "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
         },
+        "applicationId": {
+            "description": "The identifier of the appeal case",
+            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
         "defendantId": {
             "description": "The identifier of the defendant",
+            "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
+        },
+        "subjectId": {
+            "description": "The identifier of the appeal subject",
             "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
         },
         "offenceId": {
@@ -42,7 +50,7 @@
         }
     },
     "required": [
-        "prosecutionCaseId", "defendantId", "offenceId", "statusCode", "applicationReference", "statusDate", "effectiveStartDate", "defenceOrganisation"
+        "offenceId", "statusCode", "applicationReference", "statusDate", "effectiveStartDate", "defenceOrganisation"
     ],
     "additionalProperties": false
 }

--- a/spec/requests/representation_orders_spec.rb
+++ b/spec/requests/representation_orders_spec.rb
@@ -34,29 +34,63 @@ RSpec.describe "RepresentationOrders", type: :request do
     }
   end
 
-  context "when the auth header is incorrect" do
-    it "returns a response with an unauthorised status" do
-      post "/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params
-      expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  context "when the auth header is correct" do
-    let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch("SHARED_SECRET_KEY") } }
-
-    context "when the LaaReference exists" do
-      before { laa_reference.save! }
-
-      it "returns an accepted status" do
-        post("/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params, headers:)
-        expect(response).to have_http_status(:accepted)
+  describe "cases" do
+    context "when the auth header is incorrect" do
+      it "returns a response with an unauthorised status" do
+        post "/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    context "when the LaaReference is new" do
-      it "returns an accepted status" do
-        post("/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params, headers:)
-        expect(response).to have_http_status(:accepted)
+    context "when the auth header is correct" do
+      let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch("SHARED_SECRET_KEY") } }
+
+      context "when the LaaReference exists" do
+        before { laa_reference.save! }
+
+        it "returns an accepted status" do
+          post("/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params, headers:)
+          expect(response).to have_http_status(:accepted)
+        end
+      end
+
+      context "when the LaaReference is new" do
+        it "returns an accepted status" do
+          post("/prosecutionCases/representationOrder/cases/#{defendant.prosecution_case.id}/defendants/#{defendant.id}/offences/#{offence.id}", params: laa_reference_params, headers:)
+          expect(response).to have_http_status(:accepted)
+        end
+      end
+    end
+  end
+
+  describe "application" do
+    let(:subject_id) { SecureRandom.uuid }
+    let(:application_id) { SecureRandom.uuid }
+
+    context "when the auth header is incorrect" do
+      it "returns a response with an unauthorised status" do
+        post "/prosecutionCases/representationOrder/application/#{application_id}/subject/#{subject_id}/offences/#{offence.id}", params: laa_reference_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when the auth header is correct" do
+      let(:headers) { { 'Ocp-Apim-Subscription-Key': ENV.fetch("SHARED_SECRET_KEY") } }
+
+      context "when the LaaReference exists" do
+        before { laa_reference.save! }
+
+        it "returns an accepted status" do
+          post("/prosecutionCases/representationOrder/application/#{application_id}/subject/#{subject_id}/offences/#{offence.id}", params: laa_reference_params, headers:)
+          expect(response).to have_http_status(:accepted)
+        end
+      end
+
+      context "when the LaaReference is new" do
+        it "returns an accepted status" do
+          post("/prosecutionCases/representationOrder/application/#{application_id}/subject/#{subject_id}/offences/#{offence.id}", params: laa_reference_params, headers:)
+          expect(response).to have_http_status(:accepted)
+        end
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-586)

Add a new endpoint that can add representation orders to application subject offences
Since the prosecution case endpoint doesn't really care about the prosecution case, I _think_ we can simply reuse the same logic wholesale, and simply be a bit more permissive in the schema.

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
