### PR TITLE
ACD-416: Add mechanism to publish conclusion of an application

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,8 @@
  *= require_tree .
  *= require_self
  */
+
+ .field_with_errors {
+  display: inline-block;
+  color: red;
+ }

--- a/app/controllers/admin/application_conclusions_controller.rb
+++ b/app/controllers/admin/application_conclusions_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class ApplicationConclusionsController < Admin::ApplicationController
+    def create
+      CourtApplicationConcluder.call(court_application_id: params[:id], publish_to: params[:publish_to])
+
+      redirect_to admin_court_application_path(params[:id]), notice: "Prosecution Case was successfully concluded."
+    end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -3,5 +3,12 @@
 module Admin
   class ApplicationController < ActionController::Base
     http_basic_authenticate_with name: ENV["ADMIN_USERNAME"], password: ENV["ADMIN_PASSWORD"]
+
+  private
+
+    def set_env_list
+      @env_options = [%w[Development dev], %w[Test test], %w[Stage stage]]
+      @default_env = "dev"
+    end
   end
 end

--- a/app/controllers/admin/court_applications_controller.rb
+++ b/app/controllers/admin/court_applications_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class CourtApplicationsController < Admin::ApplicationController
+    before_action :set_env_list, only: :show
+
     def index
       scope = CourtApplication.order(created_at: :desc)
       scope = scope.where(id: params[:query]) if params[:query].present?
@@ -78,7 +80,8 @@ module Admin
                                                 :breachedOrder,
                                                 :hearing_id,
                                                 :defendant_id,
-                                                :court_application_type_id)
+                                                :court_application_type_id,
+                                                :result_code)
     end
   end
 end

--- a/app/controllers/admin/prosecution_cases_controller.rb
+++ b/app/controllers/admin/prosecution_cases_controller.rb
@@ -59,11 +59,6 @@ module Admin
       @prosecution_case = ProsecutionCase.find(params[:id])
     end
 
-    def set_env_list
-      @env_options = [%w[Development dev], %w[Test test], %w[Stage stage]]
-      @default_env = "dev"
-    end
-
     # Only allow a list of trusted parameters through.
     def prosecution_case_params
       params.require(:prosecution_case).permit(:originatingOrganisation,

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,4 +22,12 @@ import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 import "@kollegorna/cocoon-vanilla-js";
 
-console.log('Hello World from Webpacker')
+document.addEventListener('DOMContentLoaded', function() {
+  const selectBox = document.getElementById('environment_select');
+
+  selectBox?.addEventListener('change', function() {
+    document.querySelectorAll('[button_group="environment_based"]').forEach((element) => {
+      element.style.display = element.attributes.target_env.value == selectBox.value ? "block" : "none"
+    });
+  });
+});

--- a/app/models/application_conclusion.rb
+++ b/app/models/application_conclusion.rb
@@ -1,0 +1,36 @@
+class ApplicationConclusion
+  include ActiveModel::Model
+
+  attr_reader :court_application
+
+  delegate :defendant, to: :court_application
+
+  def initialize(court_application:)
+    @court_application = court_application
+  end
+
+  def to_builder
+    Jbuilder.new do |application_conclusion|
+      application_conclusion.applicationConcluded conclusion_summary.attributes!
+      application_conclusion.isConcluded true
+      application_conclusion.hearingIdWhereChangeOccurred defendant.prosecution_case.hearings.last.id
+      application_conclusion.offenceSummary offence_summary_builder
+    end
+  end
+
+private
+
+  def offence_summary_builder
+    defendant.offences.map do |offence|
+      ProsecutionConclusionOffenceSummary.new(offence:).to_builder.attributes!
+    end
+  end
+
+  def conclusion_summary
+    Jbuilder.new do |conclusion_summary|
+      conclusion_summary.applicationId = court_application.id
+      conclusion_summary.applicationResultCode = court_application.result_code
+      conclusion_summary.subjectId = defendant.id
+    end
+  end
+end

--- a/app/models/application_conclusion.rb
+++ b/app/models/application_conclusion.rb
@@ -28,9 +28,9 @@ private
 
   def conclusion_summary
     Jbuilder.new do |conclusion_summary|
-      conclusion_summary.applicationId = court_application.id
-      conclusion_summary.applicationResultCode = court_application.result_code
-      conclusion_summary.subjectId = defendant.id
+      conclusion_summary.applicationId court_application.id
+      conclusion_summary.applicationResultCode court_application.result_code
+      conclusion_summary.subjectId defendant.id
     end
   end
 end

--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -4,6 +4,10 @@ class CourtApplication < ApplicationRecord
   include BuilderMappable
   include CourtCentreRelatable
 
+  RESULT_CODES = [
+    "G /STDEC", "RFSD", "WDRN", "D", "G / ROPENED", "RFSD", "WDRN"
+  ].freeze
+
   belongs_to :court_application_party
   belongs_to :court_application_payment, optional: true
   belongs_to :court_application_type
@@ -26,6 +30,7 @@ class CourtApplication < ApplicationRecord
   validates :applicationReceivedDate, presence: true
   validates :court_application_party, presence: true
   validates :applicationStatus, presence: true, inclusion: %w[DRAFT LISTED FINALISED]
+  validates :result_code, inclusion: { in: RESULT_CODES, allow_blank: true }
 
   def to_builder
     Jbuilder.new do |court_application|
@@ -44,5 +49,11 @@ class CourtApplication < ApplicationRecord
       court_application.subject court_application_party.to_builder
       court_application.respondents array_builder(respondents)
     end
+  end
+
+  def conclusion_payload
+    application_conclusion = ApplicationConclusion.new(court_application: self).to_builder.attributes!
+
+    { prosecutionConcluded: [application_conclusion] }.to_json
   end
 end

--- a/app/services/application_conclusion_publisher.rb
+++ b/app/services/application_conclusion_publisher.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ApplicationConclusionPublisher < ApplicationService
+  URL = "/api/external/v1/prosecution_conclusions"
+
+  def initialize(court_application:, type: :dev)
+    @court_application = court_application
+    @type = type
+  end
+
+  def call
+    connection.post(URL, court_application.conclusion_payload)
+  end
+
+private
+
+  attr_reader :court_application, :type
+
+  def connection
+    @connection ||= LaaConnector.call(**Rails.configuration.laa_connection[type])
+  end
+end

--- a/app/services/court_application_concluder.rb
+++ b/app/services/court_application_concluder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CourtApplicationConcluder < ApplicationService
+  def initialize(court_application_id:, publish_to: nil)
+    @court_application = CourtApplication.find(court_application_id)
+    @publish_to = Rails.configuration.laa_connection.key?(publish_to&.to_sym) ? publish_to : nil
+  end
+
+  def call
+    court_application.defendant.prosecution_case.update!(concluded: true)
+    ApplicationConclusionPublisher.call(court_application:, type: publish_to) if publish_to.present?
+  end
+
+private
+
+  attr_reader :court_application, :publish_to
+end

--- a/app/views/admin/court_applications/_form.html.erb
+++ b/app/views/admin/court_applications/_form.html.erb
@@ -53,12 +53,18 @@
     <%= f.label :breachedOrder, 'Breached Order' %>
     <%= f.text_field :breachedOrder %>
   </div>
+  <div class="field">
+    <%= f.label :result_code, 'Result code' %>
+    <%= f.select :result_code,
+                 options_for_select(CourtApplication::RESULT_CODES, @court_application.result_code),
+                 prompt: "Select a result code" %>
+  </div>
   <% if @defendants.present? %>
     <div class="field">
       <%= f.label :defendant_id, "Select Defendant" %>
-      <%= f.select :defendant_id, options_for_select(@defendants.all.collect { |defendant| 
+      <%= f.select :defendant_id, options_for_select(@defendants.all.collect { |defendant|
                     [ "#{defendant.defendable.person.first_name} #{defendant.defendable.person.middle_name} #{defendant.defendable.person.last_name}",
-                    defendant.id] }, @court_application.defendant_id), 
+                    defendant.id] }, @court_application.defendant_id),
                     prompt: "Select a user" %>
     </div>
   <% end %>
@@ -66,7 +72,7 @@
       <div class="field">
         <p><strong>So that the existing api endpoint work as expected</strong></p>
       <%= f.label :hearing_id, "Select Main Hearing" %>
-      <%= f.select :hearing_id, options_for_select(@hearings.all.collect { |hearing| 
+      <%= f.select :hearing_id, options_for_select(@hearings.all.collect { |hearing|
                     [ hearing.id,
                     hearing.id] }, @court_application.hearing_id),
                     prompt: "Select a hearing"%>

--- a/app/views/admin/court_applications/edit.html.erb
+++ b/app/views/admin/court_applications/edit.html.erb
@@ -1,4 +1,14 @@
 <%= form_with(model: @court_application, local: true, url: admin_court_application_path) do |form| %>
+  <% if @court_application.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@court_application.errors.count, "error") %> prevented this application from being saved:</h2>
+      <ul>
+        <% @court_application.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render 'form', f: form %>
   <%= form.submit %>
 <% end %>

--- a/app/views/admin/court_applications/show.html.erb
+++ b/app/views/admin/court_applications/show.html.erb
@@ -69,16 +69,3 @@
   <%= link_to 'Back to Hearing', admin_hearing_path(@court_application.hearing) %>
 <% end %>
 </div>
-
-
-<script type="text/javascript">
-  document.addEventListener('DOMContentLoaded', function() {
-    const selectBox = document.getElementById('environment_select');
-
-    selectBox.addEventListener('change', function() {
-      document.querySelectorAll('[button_group="environment_based"]').forEach((element) => {
-        element.style.display = element.attributes.target_env.value == selectBox.value ? "block" : "none"
-      });
-    });
-  });
-</script>

--- a/app/views/admin/court_applications/show.html.erb
+++ b/app/views/admin/court_applications/show.html.erb
@@ -9,6 +9,20 @@
 </ul>
 
 <%= link_to 'Edit', edit_admin_court_application_path(@court_application) %>
+
+<h3>Conclusion options</h3>
+<%= select_tag :environment_select, options_for_select(@env_options, @default_env) %>
+<br><br>
+<% @env_options.each do |option| %>
+  <%=
+    button_to "Conclude and Publish to #{option[0]}",
+              admin_application_conclusions_path(@court_application.id, option[1]),
+              :id => "publish-application-#{option[1]}",
+              :target_env => option[1],
+              :button_group => "environment_based",
+              :style => (option[1] == @default_env ? "display: block;" : "display: none;")
+  %>
+<% end %>
 <h2>Court Application Type</h2>
 
 <ul>
@@ -55,3 +69,16 @@
   <%= link_to 'Back to Hearing', admin_hearing_path(@court_application.hearing) %>
 <% end %>
 </div>
+
+
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function() {
+    const selectBox = document.getElementById('environment_select');
+
+    selectBox.addEventListener('change', function() {
+      document.querySelectorAll('[button_group="environment_based"]').forEach((element) => {
+        element.style.display = element.attributes.target_env.value == selectBox.value ? "block" : "none"
+      });
+    });
+  });
+</script>

--- a/app/views/admin/prosecution_cases/show.html.erb
+++ b/app/views/admin/prosecution_cases/show.html.erb
@@ -112,15 +112,3 @@
 
 <%= link_to 'Edit', edit_admin_prosecution_case_path(@prosecution_case) %> |
 <%= link_to 'Back', admin_prosecution_cases_path %>
-
-<script type="text/javascript">
-  document.addEventListener('DOMContentLoaded', function() {
-    const selectBox = document.getElementById('environment_select');
-
-    selectBox.addEventListener('change', function() {
-      document.querySelectorAll('[button_group="environment_based"]').forEach((element) => {
-        element.style.display = element.attributes.target_env.value == selectBox.value ? "block" : "none"
-      });
-    });
-  });
-</script>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -22,7 +22,7 @@
   <%= javascript_pack_tag 'application' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= stylesheet_pack_tag 'govuk', 'data-turbolinks-track': 'reload' %>
-  <%= javascript_pack_tag 'govuk', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'govuk', 'data-turbolinks-track': 'reload', 'type': 'module' %>
 
   <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
 </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     post "prosecution_conclusions/:id(/:publish_to)" => "prosecution_conclusions#create", as: :prosecution_conclusions
+    post "application_conclusions/:id(/:publish_to)" => "application_conclusions#create", as: :application_conclusions
     get "court_applications" => "court_applications#index"
 
     resources :prosecution_cases, shallow: true do

--- a/db/migrate/20250328091423_add_result_code_to_court_applications.rb
+++ b/db/migrate/20250328091423_add_result_code_to_court_applications.rb
@@ -1,0 +1,5 @@
+class AddResultCodeToCourtApplications < ActiveRecord::Migration[8.0]
+  def change
+    add_column :court_applications, :result_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_28_053143) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_28_091423) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
 
   create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "address1", null: false
@@ -333,6 +333,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_053143) do
     t.uuid "hearing_id"
     t.uuid "court_application_type_id"
     t.uuid "defendant_id"
+    t.string "result_code"
     t.index ["court_application_outcome_id"], name: "index_court_applications_on_court_application_outcome_id"
     t.index ["court_application_party_id"], name: "index_court_applications_on_court_application_party_id"
     t.index ["court_application_payment_id"], name: "index_court_applications_on_court_application_payment_id"

--- a/spec/cassettes/court_applications/concluded/success.yml
+++ b/spec/cassettes/court_applications/concluded/success.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<LAA_DEV_API_URL>/oauth/token"
+    body:
+      encoding: UTF-8
+      string: client_id=<LAA_DEV_CLIENT_ID>&client_secret=<LAA_DEV_CLIENT_SECRET>&grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Thu, 13 Jan 2022 18:50:58 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      cache-control:
+      - no-store
+      pragma:
+      - no-cache
+      vary:
+      - Accept
+      etag:
+      - W/"14ee28c5a201dd8398c0c88904cfb880"
+      x-request-id:
+      - ed2198809a6e650cce1e999c0377aa62
+      x-runtime:
+      - '0.063362'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"<ACCESS_TOKEN>","token_type":"Bearer","expires_in":300,"created_at":1642099858}'
+  recorded_at: Thu, 13 Jan 2022 18:50:58 GMT
+- request:
+    method: post
+    uri: "<LAA_DEV_API_URL>/api/external/v1/prosecution_conclusions"
+    body:
+      encoding: UTF-8
+      string: '{"prosecutionConcluded":[{"applicationConcluded":{"applicationId=":"f0b9662f-5fb8-4d6c-b7c5-40b0c067b943","subjectId=":"a4371876-7c52-4f18-86bb-f0589adc5bf5"},"isConcluded":true,"hearingIdWhereChangeOccurred":"f5979f49-6292-4bcb-bce9-d855f15849f1","offenceSummary":[{"offenceId":"87ce10f7-228f-4ca9-8e3e-9cd9cc92ef2a","offenceCode":"PT00011","proceedingsConcluded":false,"proceedingsConcludedChangedDate":"2021-12-17"}]}]}'
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Authorization:
+      - "<BEARER_TOKEN>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      date:
+      - Thu, 13 Jan 2022 18:50:58 GMT
+      content-type:
+      - text/html
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      laa-transaction-id:
+      - 828e9701e216dfef0e01bfb4e339b76a
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 828e9701e216dfef0e01bfb4e339b76a
+      x-runtime:
+      - '0.032515'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 13 Jan 2022 18:50:58 GMT
+recorded_with: VCR 6.3.1

--- a/spec/requests/admin/application_conclusions_spec.rb
+++ b/spec/requests/admin/application_conclusions_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "/admin/application_conclusions/:id", type: :request do
+  let(:court_application) { FactoryBot.create(:court_application) }
+  let(:headers) { { 'Authorization': authorisation } }
+  let(:authorisation) { ActionController::HttpAuthentication::Basic.encode_credentials(ENV["ADMIN_USERNAME"], ENV["ADMIN_PASSWORD"]) }
+  let(:type) { "dev" }
+
+  it "calls the CourtApplicationConcluder" do
+    expect(CourtApplicationConcluder).to receive(:call).with(court_application_id: court_application.id, publish_to: type)
+    post "/admin/application_conclusions/#{court_application.id}/#{type}", headers:
+  end
+end

--- a/spec/services/application_conclusion_publisher_spec.rb
+++ b/spec/services/application_conclusion_publisher_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe ApplicationConclusionPublisher do
+  subject(:publisher) { described_class.call(court_application:) }
+
+  let(:court_application) { FactoryBot.create(:court_application, defendant: create(:defendant)) }
+
+  context "with valid params" do
+    it "sends a payload to LAA prosecution conclusions endpoint" do
+      VCR.use_cassette("court_applications/concluded/success") do
+        expect(publisher.status).to eq(202)
+      end
+    end
+  end
+
+  context "with connection" do
+    subject(:call_publisher) { described_class.call(court_application:) }
+
+    let(:connection) { class_double(Faraday) }
+
+    before do
+      allow(LaaConnector).to receive(:call).and_return(connection)
+    end
+
+    it "makes a POST request" do
+      expect(connection).to receive(:post)
+      call_publisher
+    end
+  end
+end

--- a/spec/services/court_application_concluder_spec.rb
+++ b/spec/services/court_application_concluder_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe CourtApplicationConcluder do
+  subject(:publish) { described_class.call(court_application_id: court_application.id, publish_to:) }
+
+  let(:court_application) { FactoryBot.create(:court_application, defendant: create(:defendant)) }
+  let(:publish_to) { "dev" }
+
+  before { allow(ApplicationConclusionPublisher).to receive(:call) }
+
+  it "triggers the publisher" do
+    expect(ApplicationConclusionPublisher).to receive(:call).with(court_application: court_application, type: "dev")
+    publish
+  end
+
+  it "concludes the prosecution case" do
+    publish
+    expect(court_application.defendant.prosecution_case.reload.concluded).to be(true)
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-416)

- Add a button on the court application page allowing us to publish the conclusion of an application to different environments
- Add a result_code attribute to court applications and a UI to set the result code
- Generate a new payload that gets sent to the existing prosecution conclusion CDA endpoint

## Checklist

Before you ask people to review this PR:

- [x] Tests and linters should be passing
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
