### PR TITLE
Make concluding appeals work properly

### DIFF
--- a/app/services/court_application_concluder.rb
+++ b/app/services/court_application_concluder.rb
@@ -8,6 +8,7 @@ class CourtApplicationConcluder < ApplicationService
 
   def call
     court_application.defendant.prosecution_case.update!(concluded: true)
+    court_application.defendant.offences.update_all(isDisposed: true)
     ApplicationConclusionPublisher.call(court_application:, type: publish_to) if publish_to.present?
   end
 

--- a/spec/services/court_application_concluder_spec.rb
+++ b/spec/services/court_application_concluder_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe CourtApplicationConcluder do
     publish
     expect(court_application.defendant.prosecution_case.reload.concluded).to be(true)
   end
+
+  it "marks the offences as disposed" do
+    offence = court_application.defendant.offences.first
+    expect(offence).not_to be_isDisposed
+    publish
+    expect(offence.reload).to be_isDisposed
+  end
 end


### PR DESCRIPTION
## What
The mock sets the `proceedingsConcluded` value of the appeal payload based on whether all offences are "disposed", so we need to make sure that we set them all as disposed when we conclude the appeal.
