### PR TITLE
ACD-757: Add masterDefendantId to the defendant payload

### DIFF
--- a/app/models/defendant_summary.rb
+++ b/app/models/defendant_summary.rb
@@ -28,6 +28,7 @@ class DefendantSummary
       defendant_summary.dateOfNextHearing date_of_next_hearing
       defendant_summary.proceedingsConcluded proceedings_concluded?
       defendant_summary.offenceSummary offences_builder
+      defendant_summary.masterDefendantId defendant.masterDefendantId
     end
   end
 

--- a/lib/schemas/global/search/apiDefendantSummary.json
+++ b/lib/schemas/global/search/apiDefendantSummary.json
@@ -8,6 +8,10 @@
             "description": "The identifier of the defendant",
             "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid"
         },
+        "masterDefendantId": {
+          "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/uuid",
+          "description": "Technical identifier that uniquely identifies the defendant on CPP i.e. across prosecution cases.  Case defendants that are the same person will be matched and provided the same defendantMasterId"
+        },
         "defendantNINO": {
           "description": "The person nino when the defendant is a person",
           "$ref": "http://justice.gov.uk/core/courts/external/apiCourtsDefinitions.json#/definitions/nino"


### PR DESCRIPTION
## What
The real HMCTS returns masterDefendantId as part of the payload. This PR updates the mock to do the same.
[Link to story](https://dsdmoj.atlassian.net/browse/ACD-757)
