### PR TITLE
ACD-698: Allow associating multiple prosecution cases with a court application

### DIFF
--- a/app/controllers/admin/court_applications_controller.rb
+++ b/app/controllers/admin/court_applications_controller.rb
@@ -96,11 +96,7 @@ module Admin
     def set_application_and_case
       @court_application = CourtApplication.find(params[:id])
       @court_application_hearings = @court_application.court_hearings
-
-      if @court_application.prosecution_cases.any?
-        prosecution_cases = @court_application.prosecution_cases
-        @prosecution_case_hearings = prosecution_cases.flat_map(&:hearings)
-      end
+      @prosecution_case_hearings = @court_application.prosecution_cases.flat_map(&:hearings)
 
       if @court_application.defendant
         @available_cases = ProsecutionCase.joins(:defendants)

--- a/app/controllers/admin/prosecution_cases_controller.rb
+++ b/app/controllers/admin/prosecution_cases_controller.rb
@@ -60,10 +60,8 @@ module Admin
     end
 
     def associate_court_application
-      p_case = ProsecutionCase.find(params[:id])
-      court_application = CourtApplication.find(params[:court_application_id])
-      court_application.prosecution_cases << p_case
-      redirect_to admin_court_application_path(court_application), flash: { notice: "Case associated" }
+      create_court_application_association
+      redirect_to admin_court_application_path(params[:court_application_id]), flash: { notice: "Case associated" }
     end
 
   private
@@ -210,6 +208,12 @@ module Admin
 
     def add_breadcrumbs
       breadcrumbs.add(@prosecution_case.prosecution_case_identifier.caseURN)
+    end
+
+    def create_court_application_association
+      p_case = ProsecutionCase.find(params[:id])
+      court_application = CourtApplication.find(params[:court_application_id])
+      court_application.prosecution_cases << p_case
     end
   end
 end

--- a/app/controllers/admin/prosecution_cases_controller.rb
+++ b/app/controllers/admin/prosecution_cases_controller.rb
@@ -18,6 +18,12 @@ module Admin
 
     def new
       @prosecution_case = FactoryBot.build(:realistic_prosecution_case)
+
+      if params[:defendant_id]
+        defendant = Defendant.find(params[:defendant_id])
+        @prosecution_case.defendants.first.masterDefendantId = defendant.masterDefendantId
+        @prosecution_case.defendants.first.defendable.person = defendant.defendable.person.dup
+      end
     end
 
     def edit; end
@@ -51,6 +57,13 @@ module Admin
       else
         render :edit
       end
+    end
+
+    def associate_court_application
+      p_case = ProsecutionCase.find(params[:id])
+      court_application = CourtApplication.find(params[:court_application_id])
+      court_application.prosecution_cases << p_case
+      redirect_to admin_court_application_path(court_application), flash: { notice: "Case associated" }
     end
 
   private

--- a/app/models/court_application.rb
+++ b/app/models/court_application.rb
@@ -18,8 +18,8 @@ class CourtApplication < ApplicationRecord
   has_many :respondents, class_name: "CourtApplicationParty", dependent: :destroy
 
   # only used for application enpoint
-  has_many :court_application_prosecution_case, dependent: :destroy
-  has_many :prosecution_case, through: :court_application_prosecution_case
+  has_many :court_application_prosecution_cases, dependent: :destroy
+  has_many :prosecution_cases, through: :court_application_prosecution_cases
 
   # only used for application enpoint
   has_many :court_application_hearing, dependent: :destroy

--- a/app/models/court_application_summary.rb
+++ b/app/models/court_application_summary.rb
@@ -22,7 +22,7 @@ class CourtApplicationSummary
       application_case_summary.applicationType court_application.court_application_type.code
       application_case_summary.receivedDate court_application.applicationReceivedDate.to_date
       application_case_summary.applicationResult court_application.result_code
-      application_case_summary.caseSummary prosecution_cases_builder if @court_application.prosecution_case.present?
+      application_case_summary.caseSummary prosecution_cases_builder if @court_application.prosecution_cases.present?
       application_case_summary.hearingSummary hearings_builder if @court_application.hearing.present?
       application_case_summary.judicialResults court_application.judicial_results if @court_application.judicial_results.present?
       application_case_summary.subjectSummary defendants_builder if @court_application.defendant.present?
@@ -31,12 +31,8 @@ class CourtApplicationSummary
 
 private
 
-  def prosecution_case_reference
-    prosecution_case.prosecution_case_identifier.caseURN || prosecution_case.prosecution_case_identifier.prosecutionAuthorityReference
-  end
-
   def prosecution_cases_builder
-    court_application.prosecution_case.ids.map do |prosecution_case_id|
+    court_application.prosecution_cases.ids.map do |prosecution_case_id|
       CourtApplicationProsecutionCaseSummary.new(prosecution_case_id:).to_builder.attributes!
     end
   end

--- a/app/views/admin/court_applications/show.html.erb
+++ b/app/views/admin/court_applications/show.html.erb
@@ -63,6 +63,27 @@
   </ul>
 <% end %>
 
+
+<h2>Prosecution cases</h2>
+<ul>
+  <% @court_application.prosecution_cases.each do |prosecution_case| %>
+    <li>
+      <%= link_to prosecution_case.prosecution_case_identifier.caseURN, admin_prosecution_case_path(prosecution_case) %>
+    </li>
+  <% end %>
+</ul>
+
+<% if @available_cases&.any? %>
+  <h3>Available prosecution cases</h3>
+  <ul>
+    <% @available_cases.each do |prosecution_case| %>
+      <li>
+        <%= prosecution_case.prosecution_case_identifier.caseURN %>
+        <%= button_to "Associate", associate_court_application_admin_prosecution_case_path(prosecution_case, @court_application) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 <hr>
 
 

--- a/app/views/admin/defendants/show.html.erb
+++ b/app/views/admin/defendants/show.html.erb
@@ -42,5 +42,7 @@
 <div class="links">
   <%= link_to 'Add court application', admin_defendant_defendants_court_applications_path(@defendant), method: :post %>
 </div>
+
 <%= link_to 'Edit', edit_admin_defendant_path(@defendant) %> |
+  <%= link_to 'Add prosecution case', new_admin_prosecution_case_path(defendant_id: @defendant.id) %> |
 <%= link_to 'Back', admin_prosecution_case_path(@defendant.prosecution_case) %>

--- a/app/views/admin/prosecution_cases/show.html.erb
+++ b/app/views/admin/prosecution_cases/show.html.erb
@@ -32,8 +32,9 @@
 <% end %>
 
 
-<h2>Defendants</h2>
+
 <table>
+  <caption><h2>Defendants</h2></caption>
   <thead>
     <tr>
       <th>Defendant ID</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     resources :prosecution_cases, shallow: true do
       member do
         post "result/:hearing_id(/:publish_to)" => "prosecution_cases#result", as: :result_hearing
+        post "associate_court_application/:court_application_id" => "prosecution_cases#associate_court_application",
+             as: :associate_court_application
       end
 
       resources :defendants do

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -56,6 +56,7 @@ FactoryBot.define do
     croNumber { Faker::Code.asin }
     pncId { Faker::Code.rut }
     mergedProsecutionCaseReference { Faker::Lorem.word }
+    masterDefendantId { SecureRandom.uuid }
 
     association :defendable, factory: :realistic_person_defendant
     trait :with_legal_entity_defendant do

--- a/spec/features/multiple_cases_spec.rb
+++ b/spec/features/multiple_cases_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "support/when_authenticated"
+
+RSpec.describe "adding a new prosecution case to a court applicaiton", type: :feature do
+  include_context "when authenticated"
+
+  it "lets me walk through" do
+    visit root_path
+    click_on "New Prosecution Case"
+    click_on "Create Prosecution case"
+    first_pc = ProsecutionCase.first
+    within :table, "Defendants" do
+      click_on "Show"
+    end
+
+    click_on "Add prosecution case"
+    click_on "Create Prosecution case"
+    second_pc = ProsecutionCase.where.not(id: first_pc.id).first
+
+    expect(first_pc.defendants.first.masterDefendantId).to eq second_pc.defendants.first.masterDefendantId
+    expect(first_pc.defendants.first.defendable.person.firstName).to eq second_pc.defendants.first.defendable.person.firstName
+
+    within :table, "Defendants" do
+      click_on "Show"
+    end
+
+    click_on "Add court application"
+    click_on "Show"
+
+    expect(page).to have_content "Prosecution cases\n#{second_pc.prosecution_case_identifier.caseURN}"
+    expect(page).to have_content "Available prosecution cases\n#{first_pc.prosecution_case_identifier.caseURN}"
+
+    click_on "Associate"
+    expect(page).to have_content "Case associated"
+
+    application = CourtApplication.first
+    expect(application.prosecution_cases.to_set).to eq [second_pc, first_pc].to_set
+    expect(application.defendant.masterDefendantId).to eq first_pc.defendants.first.masterDefendantId
+  end
+end

--- a/spec/requests/admin/court_applications_controller_spec.rb
+++ b/spec/requests/admin/court_applications_controller_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe "/admin/court_application", type: :request do
     end
 
     it "assigns @defendants from prosecution_case" do
-      prosecution_case = ProsecutionCase.find(court_application.prosecution_case)
+      prosecution_case = court_application.prosecution_cases.first.reload
       expect(assigns(:defendants)).to eq(prosecution_case.defendants)
     end
 
     it "assigns @hearings from prosecution_case" do
-      prosecution_case = ProsecutionCase.find(court_application.prosecution_case)
+      prosecution_case = court_application.prosecution_cases.first.reload
       expect(assigns(:hearings)).to eq(prosecution_case.hearings)
     end
   end


### PR DESCRIPTION
## What
Add UI controls to make it possible to have 2 prosecution cases whose defendants are the same person (i.e. they share a masterDefendantId), and associate both cases with a single court application that is tagged to that masterDefendantId.

[Link to story](https://dsdmoj.atlassian.net/browse/-ACD-698)

