### PR TITLE
Remove unnecessary asset config

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,6 +10,3 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-
-# Add node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join("node_modules")


### PR DESCRIPTION
## What
I don't know why this only very recently seemed to start biting us, but this line not only unnecessary, it also means that when running locally, for any Rails action that inherits from ActionController::Base rather than ActionController::API, Rails seems to read through the entire contents of the node_modules folder, which can take up to a minute, for no good reason.
