### PR TITLE
ACD-949: (Breaches/POCA) Add defendantJudicialResults to hearing payload

### DIFF
--- a/app/models/defendant_judicial_result.rb
+++ b/app/models/defendant_judicial_result.rb
@@ -7,7 +7,7 @@ class DefendantJudicialResult < ApplicationRecord
   def to_builder
     Jbuilder.new do |defendant_judicial_result|
       defendant_judicial_result.masterDefendantId master_defendant_id
-      defendant_judicial_result.judicialResult judicial_result.to_builder
+      defendant_judicial_result.judicialResult judicial_result.to_builder.attributes!
     end
   end
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -19,6 +19,7 @@ class Hearing < ApplicationRecord
   has_many :referral_reasons
   has_many :hearing_case_notes
   has_many :hearing_days, inverse_of: :hearing, dependent: :destroy
+  has_many :judicial_results, dependent: :destroy
   has_many :judicial_roles
   has_many :applicant_counsels
   has_many :respondent_counsels
@@ -65,6 +66,7 @@ class Hearing < ApplicationRecord
       hearing.defendantAttendance array_builder(defendant_attendances)
       hearing.defendantHearingYouthMarkers array_builder(defendant_hearing_youth_markers)
       hearing.courtApplicationPartyAttendance array_builder(court_application_party_attendances)
+      hearing.defendantJudicialResults array_builder(judicial_results.map(&:defendant_judicial_result))
     end
   end
 

--- a/app/models/judicial_result.rb
+++ b/app/models/judicial_result.rb
@@ -62,4 +62,11 @@ class JudicialResult < ApplicationRecord
       judicial_result.judicialResultPrompts array_builder(judicial_result_prompts)
     end
   end
+
+  def defendant_judicial_result
+    @defendant_judicial_result ||= DefendantJudicialResult.new(
+      master_defendant_id: defendant&.masterDefendantId,
+      judicial_result: self,
+    )
+  end
 end


### PR DESCRIPTION
## What
There was always supposed to be a `defendantJudicialResults` section in the hearing payload, but we never used it before, so we've always ignored it. This PR fixes that since we now need that section for breaches

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-949)
